### PR TITLE
feat(server): add queue HTTP API with in-memory storage

### DIFF
--- a/server/cmd/moldd/main.go
+++ b/server/cmd/moldd/main.go
@@ -4,9 +4,10 @@
 
 // Command moldd is the MoldChat relay server.
 //
-// In its current form it only exposes a liveness endpoint; the queue, sealed
-// envelope routing, and anti-spam layers are added in subsequent development
-// steps.
+// The current build exposes a queue HTTP API backed by in-memory storage and
+// authorises owners by constant-time comparison against the public key
+// supplied at queue creation. Sealed-sender routing, persistence, anti-spam,
+// and key transparency are not implemented yet.
 package main
 
 import (
@@ -19,11 +20,13 @@ import (
 	"syscall"
 	"time"
 
+	v1 "github.com/WissCore/moldchat/server/internal/api/v1"
 	"github.com/WissCore/moldchat/server/internal/health"
+	"github.com/WissCore/moldchat/server/internal/storage/memory"
 )
 
 const (
-	defaultAddr       = ":8443"
+	defaultAddr       = ":8080"
 	readHeaderTimeout = 10 * time.Second
 	shutdownTimeout   = 5 * time.Second
 )
@@ -42,6 +45,12 @@ func run() int {
 
 	mux := http.NewServeMux()
 	mux.Handle("GET /healthz", health.Handler())
+
+	api := &v1.Server{
+		Storage: memory.New(),
+		Logger:  logger,
+	}
+	api.Mount(mux)
 
 	srv := &http.Server{
 		Addr:              addr,

--- a/server/internal/api/v1/api.go
+++ b/server/internal/api/v1/api.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package v1 implements the HTTP API for opaque message queues.
+//
+// Endpoints:
+//
+//	POST   /v1/queues                       - create a queue
+//	PUT    /v1/queues/{id}/messages          - append a blob
+//	GET    /v1/queues/{id}/messages          - list pending messages (owner-only)
+//	DELETE /v1/queues/{id}/messages/{mid}    - delete a message (owner-only)
+//
+// Owner-only operations are authorised by a constant-time comparison against
+// the public key supplied at queue creation. This is a placeholder; a proper
+// Ed25519 challenge-response signature will replace it.
+package v1
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/WissCore/moldchat/server/internal/storage"
+)
+
+// Server holds dependencies shared by handlers.
+type Server struct {
+	Storage storage.Storage
+	Logger  *slog.Logger
+}
+
+// Mount registers the v1 routes on the supplied mux.
+func (s *Server) Mount(mux *http.ServeMux) {
+	mux.Handle("POST /v1/queues", s.handleCreateQueue())
+	mux.Handle("PUT /v1/queues/{id}/messages", s.handlePutMessage())
+	mux.Handle("GET /v1/queues/{id}/messages", s.handleListMessages())
+	mux.Handle("DELETE /v1/queues/{id}/messages/{mid}", s.handleDeleteMessage())
+}

--- a/server/internal/api/v1/queues.go
+++ b/server/internal/api/v1/queues.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package v1
+
+import (
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/WissCore/moldchat/server/internal/queue"
+)
+
+// maxCreateBody bounds the JSON body for queue-creation requests.
+const maxCreateBody = 4 * 1024
+
+func (s *Server) handleCreateQueue() http.Handler {
+	type request struct {
+		OwnerPubkey string `json:"owner_pubkey"`
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxCreateBody)
+
+		var req request
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid json body")
+			return
+		}
+		key, err := base64.StdEncoding.DecodeString(req.OwnerPubkey)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "owner_pubkey must be base64-encoded")
+			return
+		}
+		q, err := s.Storage.CreateQueue(r.Context(), key)
+		switch {
+		case errors.Is(err, queue.ErrInvalidOwnerKey):
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		case err != nil:
+			s.logServerError("create queue", err)
+			writeError(w, http.StatusInternalServerError, "internal error")
+			return
+		}
+		writeJSON(w, http.StatusCreated, map[string]any{
+			"queue_id":   q.ID,
+			"expires_at": q.ExpiresAt.Format(time.RFC3339),
+		})
+	})
+}
+
+func (s *Server) handlePutMessage() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, queue.MaxBlobSize+1)
+		blob, err := io.ReadAll(r.Body)
+		if err != nil {
+			writeError(w, http.StatusRequestEntityTooLarge, "blob exceeds maximum size")
+			return
+		}
+		if len(blob) > queue.MaxBlobSize {
+			writeError(w, http.StatusRequestEntityTooLarge, "blob exceeds maximum size")
+			return
+		}
+		queueID := r.PathValue("id")
+		m, err := s.Storage.PutMessage(r.Context(), queueID, blob)
+		switch {
+		case errors.Is(err, queue.ErrQueueNotFound):
+			writeError(w, http.StatusNotFound, "queue not found")
+			return
+		case errors.Is(err, queue.ErrEmptyBlob):
+			writeError(w, http.StatusBadRequest, "empty body")
+			return
+		case errors.Is(err, queue.ErrBlobTooLarge):
+			writeError(w, http.StatusRequestEntityTooLarge, "blob exceeds maximum size")
+			return
+		case err != nil:
+			s.logServerError("put message", err)
+			writeError(w, http.StatusInternalServerError, "internal error")
+			return
+		}
+		writeJSON(w, http.StatusAccepted, map[string]any{
+			"message_id":  m.ID,
+			"accepted_at": m.ReceivedAt.Format(time.RFC3339),
+		})
+	})
+}
+
+func (s *Server) handleListMessages() http.Handler {
+	type messagePayload struct {
+		ID   string `json:"id"`
+		Blob string `json:"blob"`
+		TS   string `json:"ts"`
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queueID := r.PathValue("id")
+		q, err := s.Storage.GetQueue(r.Context(), queueID)
+		if errors.Is(err, queue.ErrQueueNotFound) {
+			writeError(w, http.StatusNotFound, "queue not found")
+			return
+		}
+		if err != nil {
+			s.logServerError("get queue", err)
+			writeError(w, http.StatusInternalServerError, "internal error")
+			return
+		}
+		if !s.authorizeOwner(r, q) {
+			writeError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		msgs, hasMore, err := s.Storage.ListMessages(r.Context(), queueID, 100)
+		if err != nil {
+			s.logServerError("list messages", err)
+			writeError(w, http.StatusInternalServerError, "internal error")
+			return
+		}
+		out := make([]messagePayload, len(msgs))
+		for i, m := range msgs {
+			out[i] = messagePayload{
+				ID:   m.ID,
+				Blob: base64.StdEncoding.EncodeToString(m.Blob),
+				TS:   m.ReceivedAt.Format(time.RFC3339),
+			}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"messages": out,
+			"has_more": hasMore,
+		})
+	})
+}
+
+func (s *Server) handleDeleteMessage() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queueID := r.PathValue("id")
+		messageID := r.PathValue("mid")
+
+		q, err := s.Storage.GetQueue(r.Context(), queueID)
+		if errors.Is(err, queue.ErrQueueNotFound) {
+			writeError(w, http.StatusNotFound, "queue not found")
+			return
+		}
+		if err != nil {
+			s.logServerError("get queue", err)
+			writeError(w, http.StatusInternalServerError, "internal error")
+			return
+		}
+		if !s.authorizeOwner(r, q) {
+			writeError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		err = s.Storage.DeleteMessage(r.Context(), queueID, messageID)
+		switch {
+		case errors.Is(err, queue.ErrMessageNotFound):
+			writeError(w, http.StatusNotFound, "message not found")
+			return
+		case err != nil:
+			s.logServerError("delete message", err)
+			writeError(w, http.StatusInternalServerError, "internal error")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+// authorizeOwner compares the X-Owner-Pubkey header (base64-encoded 32 bytes)
+// against the key supplied at queue creation, in constant time. This is a
+// placeholder for a proper Ed25519 challenge-response signature.
+func (s *Server) authorizeOwner(r *http.Request, q *queue.Queue) bool {
+	header := r.Header.Get("X-Owner-Pubkey")
+	if header == "" {
+		return false
+	}
+	key, err := base64.StdEncoding.DecodeString(header)
+	if err != nil {
+		return false
+	}
+	return subtle.ConstantTimeCompare(key, q.OwnerKey) == 1
+}
+
+func (s *Server) logServerError(op string, err error) {
+	if s.Logger == nil {
+		return
+	}
+	s.Logger.Error("server error", "op", op, "err", err.Error())
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		// Response already partially written; nothing actionable for the client.
+		return
+	}
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]any{"error": msg})
+}

--- a/server/internal/api/v1/queues_test.go
+++ b/server/internal/api/v1/queues_test.go
@@ -1,0 +1,251 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package v1_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	v1 "github.com/WissCore/moldchat/server/internal/api/v1"
+	"github.com/WissCore/moldchat/server/internal/queue"
+	"github.com/WissCore/moldchat/server/internal/storage/memory"
+)
+
+func newTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	(&v1.Server{Storage: memory.New()}).Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func randomOwnerKey(t *testing.T) (raw []byte, b64 string) {
+	t.Helper()
+	raw = make([]byte, queue.OwnerKeyBytes)
+	if _, err := rand.Read(raw); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	return raw, base64.StdEncoding.EncodeToString(raw)
+}
+
+func decodeJSON(t *testing.T, body io.Reader, dst any) {
+	t.Helper()
+	if err := json.NewDecoder(body).Decode(dst); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+}
+
+// putBlob sends a PUT request with an octet-stream body.
+func putBlob(t *testing.T, url string, body io.Reader) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPut, url, body)
+	if err != nil {
+		t.Fatalf("new put request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	return resp
+}
+
+func createQueue(t *testing.T, baseURL, ownerB64 string) string {
+	t.Helper()
+	resp, err := http.Post(baseURL+"/v1/queues", "application/json",
+		strings.NewReader(`{"owner_pubkey":"`+ownerB64+`"}`))
+	if err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create queue status: %d", resp.StatusCode)
+	}
+	var got struct {
+		QueueID string `json:"queue_id"`
+	}
+	decodeJSON(t, resp.Body, &got)
+	return got.QueueID
+}
+
+func TestCreateQueue_Happy(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+	_, b64 := randomOwnerKey(t)
+
+	resp, err := http.Post(srv.URL+"/v1/queues", "application/json",
+		strings.NewReader(`{"owner_pubkey":"`+b64+`"}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status: got %d, want 201", resp.StatusCode)
+	}
+	var got struct {
+		QueueID   string `json:"queue_id"`
+		ExpiresAt string `json:"expires_at"`
+	}
+	decodeJSON(t, resp.Body, &got)
+	if got.QueueID == "" || got.ExpiresAt == "" {
+		t.Errorf("missing fields in response: %+v", got)
+	}
+}
+
+func TestCreateQueue_InvalidKeyLength(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	body := strings.NewReader(`{"owner_pubkey":"` + base64.StdEncoding.EncodeToString([]byte("short")) + `"}`)
+	resp, err := http.Post(srv.URL+"/v1/queues", "application/json", body)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestPutMessage_RoundTrip(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+	rawKey, b64 := randomOwnerKey(t)
+	queueID := createQueue(t, srv.URL, b64)
+
+	blob := []byte("opaque-blob-content")
+	putResp := putBlob(t, srv.URL+"/v1/queues/"+queueID+"/messages", bytes.NewReader(blob))
+	defer func() { _ = putResp.Body.Close() }()
+	if putResp.StatusCode != http.StatusAccepted {
+		t.Fatalf("PUT status: got %d, want 202", putResp.StatusCode)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/v1/queues/"+queueID+"/messages", nil)
+	if err != nil {
+		t.Fatalf("new get: %v", err)
+	}
+	req.Header.Set("X-Owner-Pubkey", base64.StdEncoding.EncodeToString(rawKey))
+	getResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer func() { _ = getResp.Body.Close() }()
+
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET status: got %d, want 200", getResp.StatusCode)
+	}
+	var listed struct {
+		Messages []struct {
+			ID   string `json:"id"`
+			Blob string `json:"blob"`
+		} `json:"messages"`
+		HasMore bool `json:"has_more"`
+	}
+	decodeJSON(t, getResp.Body, &listed)
+	if len(listed.Messages) != 1 {
+		t.Fatalf("messages: got %d, want 1", len(listed.Messages))
+	}
+	got, err := base64.StdEncoding.DecodeString(listed.Messages[0].Blob)
+	if err != nil {
+		t.Fatalf("decode blob: %v", err)
+	}
+	if !bytes.Equal(got, blob) {
+		t.Errorf("blob round-trip: got %q, want %q", got, blob)
+	}
+}
+
+func TestPutMessage_QueueNotFound(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	resp := putBlob(t, srv.URL+"/v1/queues/MISSING/messages", strings.NewReader("x"))
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: got %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestPutMessage_TooLarge(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+	_, b64 := randomOwnerKey(t)
+	queueID := createQueue(t, srv.URL, b64)
+
+	resp := putBlob(t, srv.URL+"/v1/queues/"+queueID+"/messages",
+		bytes.NewReader(make([]byte, queue.MaxBlobSize+1)))
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Errorf("status: got %d, want 413", resp.StatusCode)
+	}
+}
+
+func TestListMessages_Unauthorized(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+	_, b64 := randomOwnerKey(t)
+	queueID := createQueue(t, srv.URL, b64)
+
+	noKeyResp, err := http.Get(srv.URL + "/v1/queues/" + queueID + "/messages")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer func() { _ = noKeyResp.Body.Close() }()
+	if noKeyResp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("no auth: got %d, want 401", noKeyResp.StatusCode)
+	}
+
+	wrongKey, _ := randomOwnerKey(t)
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/v1/queues/"+queueID+"/messages", nil)
+	if err != nil {
+		t.Fatalf("new get: %v", err)
+	}
+	req.Header.Set("X-Owner-Pubkey", base64.StdEncoding.EncodeToString(wrongKey))
+	wrongKeyResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer func() { _ = wrongKeyResp.Body.Close() }()
+	if wrongKeyResp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("wrong key: got %d, want 401", wrongKeyResp.StatusCode)
+	}
+}
+
+func TestDeleteMessage_RoundTrip(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+	rawKey, b64 := randomOwnerKey(t)
+	queueID := createQueue(t, srv.URL, b64)
+
+	putResp := putBlob(t, srv.URL+"/v1/queues/"+queueID+"/messages", strings.NewReader("payload"))
+	var puts struct {
+		MessageID string `json:"message_id"`
+	}
+	decodeJSON(t, putResp.Body, &puts)
+	_ = putResp.Body.Close()
+
+	req, err := http.NewRequest(http.MethodDelete, srv.URL+"/v1/queues/"+queueID+"/messages/"+puts.MessageID, nil)
+	if err != nil {
+		t.Fatalf("new delete: %v", err)
+	}
+	req.Header.Set("X-Owner-Pubkey", base64.StdEncoding.EncodeToString(rawKey))
+	delResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	defer func() { _ = delResp.Body.Close() }()
+	if delResp.StatusCode != http.StatusNoContent {
+		t.Errorf("DELETE status: got %d, want 204", delResp.StatusCode)
+	}
+}

--- a/server/internal/queue/queue.go
+++ b/server/internal/queue/queue.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package queue defines the domain types for opaque message queues.
+//
+// A queue is an append-only mailbox addressed by an opaque identifier. The
+// server treats every blob as opaque bytes; encryption and routing semantics
+// are the responsibility of clients.
+package queue
+
+import (
+	"crypto/rand"
+	"encoding/base32"
+	"errors"
+	"time"
+)
+
+// Sizing and limits for queues and messages.
+const (
+	queueIDBytes   = 20
+	messageIDBytes = 16
+
+	OwnerKeyBytes = 32
+	DefaultTTL    = 24 * time.Hour
+	MaxBlobSize   = 64 * 1024
+)
+
+// Sentinel errors returned by the storage and API layers.
+var (
+	ErrQueueNotFound   = errors.New("queue not found")
+	ErrMessageNotFound = errors.New("message not found")
+	ErrUnauthorized    = errors.New("unauthorized")
+	ErrBlobTooLarge    = errors.New("blob exceeds maximum size")
+	ErrEmptyBlob       = errors.New("blob is empty")
+	ErrInvalidOwnerKey = errors.New("owner key must be 32 bytes")
+)
+
+// Queue is the metadata for an opaque message mailbox.
+type Queue struct {
+	ID         string
+	OwnerKey   []byte
+	CreatedAt  time.Time
+	ExpiresAt  time.Time
+	LastAccess time.Time
+}
+
+// Message is a single blob stored in a queue.
+type Message struct {
+	ID         string
+	QueueID    string
+	Blob       []byte
+	ReceivedAt time.Time
+}
+
+// idEncoding is unpadded uppercase base32 (RFC 4648 §6).
+var idEncoding = base32.StdEncoding.WithPadding(base32.NoPadding)
+
+// NewID returns a fresh queue identifier (32 base32 chars from 20 random bytes).
+func NewID() (string, error) { return generateID(queueIDBytes) }
+
+// NewMessageID returns a fresh message identifier (26 base32 chars from 16 random bytes).
+func NewMessageID() (string, error) { return generateID(messageIDBytes) }
+
+func generateID(n int) (string, error) {
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return idEncoding.EncodeToString(buf), nil
+}
+
+// ValidateOwnerKey rejects keys whose length differs from OwnerKeyBytes.
+func ValidateOwnerKey(key []byte) error {
+	if len(key) != OwnerKeyBytes {
+		return ErrInvalidOwnerKey
+	}
+	return nil
+}

--- a/server/internal/queue/queue_test.go
+++ b/server/internal/queue/queue_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package queue_test
+
+import (
+	"testing"
+
+	"github.com/WissCore/moldchat/server/internal/queue"
+)
+
+func TestNewID_Unique(t *testing.T) {
+	t.Parallel()
+
+	a, err := queue.NewID()
+	if err != nil {
+		t.Fatalf("NewID: %v", err)
+	}
+	b, err := queue.NewID()
+	if err != nil {
+		t.Fatalf("NewID: %v", err)
+	}
+	if a == b {
+		t.Errorf("two NewID calls returned the same id: %s", a)
+	}
+	if got := len(a); got != 32 {
+		t.Errorf("queue id length: got %d, want 32", got)
+	}
+}
+
+func TestNewMessageID_Length(t *testing.T) {
+	t.Parallel()
+
+	id, err := queue.NewMessageID()
+	if err != nil {
+		t.Fatalf("NewMessageID: %v", err)
+	}
+	if got := len(id); got != 26 {
+		t.Errorf("message id length: got %d, want 26", got)
+	}
+}
+
+func TestValidateOwnerKey(t *testing.T) {
+	t.Parallel()
+
+	if err := queue.ValidateOwnerKey(make([]byte, 32)); err != nil {
+		t.Errorf("32-byte key rejected: %v", err)
+	}
+	if err := queue.ValidateOwnerKey(make([]byte, 31)); err == nil {
+		t.Error("31-byte key was not rejected")
+	}
+	if err := queue.ValidateOwnerKey(nil); err == nil {
+		t.Error("nil key was not rejected")
+	}
+}

--- a/server/internal/storage/memory/memory.go
+++ b/server/internal/storage/memory/memory.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package memory is an in-memory implementation of storage.Storage.
+//
+// State is lost when the process restarts; intended for tests and short-lived
+// development instances. A persistent encrypted backend can be added behind
+// the same interface without touching API code.
+package memory
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/WissCore/moldchat/server/internal/queue"
+)
+
+// Storage holds all queues and messages in process memory.
+type Storage struct {
+	mu       sync.RWMutex
+	queues   map[string]*queue.Queue
+	messages map[string][]*queue.Message
+}
+
+// New returns an empty in-memory store.
+func New() *Storage {
+	return &Storage{
+		queues:   make(map[string]*queue.Queue),
+		messages: make(map[string][]*queue.Message),
+	}
+}
+
+// CreateQueue registers a new queue owned by the given key.
+func (s *Storage) CreateQueue(_ context.Context, ownerKey []byte) (*queue.Queue, error) {
+	if err := queue.ValidateOwnerKey(ownerKey); err != nil {
+		return nil, err
+	}
+	id, err := queue.NewID()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	q := &queue.Queue{
+		ID:         id,
+		OwnerKey:   append([]byte(nil), ownerKey...),
+		CreatedAt:  now,
+		ExpiresAt:  now.Add(queue.DefaultTTL),
+		LastAccess: now,
+	}
+	s.mu.Lock()
+	s.queues[id] = q
+	s.mu.Unlock()
+	return cloneQueue(q), nil
+}
+
+// GetQueue returns a copy of the queue metadata or queue.ErrQueueNotFound.
+func (s *Storage) GetQueue(_ context.Context, id string) (*queue.Queue, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	q, ok := s.queues[id]
+	if !ok {
+		return nil, queue.ErrQueueNotFound
+	}
+	return cloneQueue(q), nil
+}
+
+// PutMessage appends an opaque blob to the queue and bumps last-access.
+func (s *Storage) PutMessage(_ context.Context, queueID string, blob []byte) (*queue.Message, error) {
+	switch {
+	case len(blob) == 0:
+		return nil, queue.ErrEmptyBlob
+	case len(blob) > queue.MaxBlobSize:
+		return nil, queue.ErrBlobTooLarge
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	q, ok := s.queues[queueID]
+	if !ok {
+		return nil, queue.ErrQueueNotFound
+	}
+	id, err := queue.NewMessageID()
+	if err != nil {
+		return nil, err
+	}
+	m := &queue.Message{
+		ID:         id,
+		QueueID:    queueID,
+		Blob:       append([]byte(nil), blob...),
+		ReceivedAt: time.Now().UTC(),
+	}
+	s.messages[queueID] = append(s.messages[queueID], m)
+	q.LastAccess = m.ReceivedAt
+	return cloneMessage(m), nil
+}
+
+// ListMessages returns up to limit messages in arrival order plus a hasMore flag.
+func (s *Storage) ListMessages(_ context.Context, queueID string, limit int) ([]*queue.Message, bool, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 100
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	q, ok := s.queues[queueID]
+	if !ok {
+		return nil, false, queue.ErrQueueNotFound
+	}
+	src := s.messages[queueID]
+	sort.SliceStable(src, func(i, j int) bool { return src[i].ReceivedAt.Before(src[j].ReceivedAt) })
+
+	hasMore := false
+	if len(src) > limit {
+		src = src[:limit]
+		hasMore = true
+	}
+	out := make([]*queue.Message, len(src))
+	for i, m := range src {
+		out[i] = cloneMessage(m)
+	}
+	q.LastAccess = time.Now().UTC()
+	return out, hasMore, nil
+}
+
+// DeleteMessage removes a single message from the queue.
+func (s *Storage) DeleteMessage(_ context.Context, queueID, messageID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	q, ok := s.queues[queueID]
+	if !ok {
+		return queue.ErrQueueNotFound
+	}
+	msgs := s.messages[queueID]
+	for i, m := range msgs {
+		if m.ID == messageID {
+			s.messages[queueID] = append(msgs[:i], msgs[i+1:]...)
+			q.LastAccess = time.Now().UTC()
+			return nil
+		}
+	}
+	return queue.ErrMessageNotFound
+}
+
+func cloneQueue(q *queue.Queue) *queue.Queue {
+	cp := *q
+	cp.OwnerKey = append([]byte(nil), q.OwnerKey...)
+	return &cp
+}
+
+func cloneMessage(m *queue.Message) *queue.Message {
+	cp := *m
+	cp.Blob = append([]byte(nil), m.Blob...)
+	return &cp
+}

--- a/server/internal/storage/memory/memory_test.go
+++ b/server/internal/storage/memory/memory_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package memory_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/WissCore/moldchat/server/internal/queue"
+	"github.com/WissCore/moldchat/server/internal/storage/memory"
+)
+
+func TestCreateQueue_RejectsInvalidKey(t *testing.T) {
+	t.Parallel()
+
+	s := memory.New()
+	if _, err := s.CreateQueue(context.Background(), make([]byte, 31)); !errors.Is(err, queue.ErrInvalidOwnerKey) {
+		t.Errorf("CreateQueue with 31-byte key: got %v, want ErrInvalidOwnerKey", err)
+	}
+}
+
+func TestPutAndListMessages_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s := memory.New()
+	ctx := context.Background()
+	q, err := s.CreateQueue(ctx, make([]byte, 32))
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+	want := []byte("opaque-blob-1")
+	if _, putErr := s.PutMessage(ctx, q.ID, want); putErr != nil {
+		t.Fatalf("PutMessage: %v", putErr)
+	}
+	msgs, hasMore, err := s.ListMessages(ctx, q.ID, 10)
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+	if hasMore {
+		t.Errorf("hasMore: got true, want false")
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("len(msgs): got %d, want 1", len(msgs))
+	}
+	if !bytes.Equal(msgs[0].Blob, want) {
+		t.Errorf("blob round-trip: got %q, want %q", msgs[0].Blob, want)
+	}
+}
+
+func TestPutMessage_RejectsEmpty(t *testing.T) {
+	t.Parallel()
+
+	s := memory.New()
+	ctx := context.Background()
+	q, err := s.CreateQueue(ctx, make([]byte, 32))
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+	if _, err := s.PutMessage(ctx, q.ID, nil); !errors.Is(err, queue.ErrEmptyBlob) {
+		t.Errorf("PutMessage(nil): got %v, want ErrEmptyBlob", err)
+	}
+}
+
+func TestPutMessage_RejectsTooLarge(t *testing.T) {
+	t.Parallel()
+
+	s := memory.New()
+	ctx := context.Background()
+	q, err := s.CreateQueue(ctx, make([]byte, 32))
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+	if _, err := s.PutMessage(ctx, q.ID, make([]byte, queue.MaxBlobSize+1)); !errors.Is(err, queue.ErrBlobTooLarge) {
+		t.Errorf("PutMessage oversized: got %v, want ErrBlobTooLarge", err)
+	}
+}
+
+func TestPutMessage_QueueNotFound(t *testing.T) {
+	t.Parallel()
+
+	s := memory.New()
+	if _, err := s.PutMessage(context.Background(), "missing", []byte("x")); !errors.Is(err, queue.ErrQueueNotFound) {
+		t.Errorf("PutMessage on missing queue: got %v, want ErrQueueNotFound", err)
+	}
+}
+
+func TestListMessages_HasMore(t *testing.T) {
+	t.Parallel()
+
+	s := memory.New()
+	ctx := context.Background()
+	q, err := s.CreateQueue(ctx, make([]byte, 32))
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		if _, putErr := s.PutMessage(ctx, q.ID, []byte{byte(i)}); putErr != nil {
+			t.Fatalf("PutMessage[%d]: %v", i, putErr)
+		}
+	}
+	msgs, hasMore, err := s.ListMessages(ctx, q.ID, 3)
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+	if !hasMore {
+		t.Errorf("hasMore: got false, want true")
+	}
+	if len(msgs) != 3 {
+		t.Errorf("len(msgs): got %d, want 3", len(msgs))
+	}
+}
+
+func TestDeleteMessage_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s := memory.New()
+	ctx := context.Background()
+	q, err := s.CreateQueue(ctx, make([]byte, 32))
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+	m, err := s.PutMessage(ctx, q.ID, []byte("payload"))
+	if err != nil {
+		t.Fatalf("PutMessage: %v", err)
+	}
+	if delErr := s.DeleteMessage(ctx, q.ID, m.ID); delErr != nil {
+		t.Fatalf("DeleteMessage: %v", delErr)
+	}
+	msgs, _, err := s.ListMessages(ctx, q.ID, 10)
+	if err != nil {
+		t.Fatalf("ListMessages after delete: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("after delete: got %d msgs, want 0", len(msgs))
+	}
+	if err := s.DeleteMessage(ctx, q.ID, m.ID); !errors.Is(err, queue.ErrMessageNotFound) {
+		t.Errorf("second DeleteMessage: got %v, want ErrMessageNotFound", err)
+	}
+}

--- a/server/internal/storage/storage.go
+++ b/server/internal/storage/storage.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package storage defines the persistence interface used by the API layer.
+//
+// The interface decouples API handlers from the backing store; an in-memory
+// implementation lives under storage/memory. Persistent encrypted backends
+// can be added behind the same interface without touching handler code.
+package storage
+
+import (
+	"context"
+
+	"github.com/WissCore/moldchat/server/internal/queue"
+)
+
+// Storage is implemented by any backing store for queues and messages.
+//
+// All methods are expected to be safe for concurrent use.
+type Storage interface {
+	CreateQueue(ctx context.Context, ownerKey []byte) (*queue.Queue, error)
+	GetQueue(ctx context.Context, id string) (*queue.Queue, error)
+	PutMessage(ctx context.Context, queueID string, blob []byte) (*queue.Message, error)
+	ListMessages(ctx context.Context, queueID string, limit int) (msgs []*queue.Message, hasMore bool, err error)
+	DeleteMessage(ctx context.Context, queueID, messageID string) error
+}


### PR DESCRIPTION
## Summary

The server gains an HTTP API for opaque message queues backed by in-memory storage. The server stores and returns opaque blobs by queue_id; payload encryption is the client's responsibility.

## Endpoints

- `POST /v1/queues` — create a queue
- `PUT /v1/queues/{id}/messages` — send a blob (≤64 KiB)
- `GET /v1/queues/{id}/messages` — read (owner only)
- `DELETE /v1/queues/{id}/messages/{mid}` — delete (owner only)

## Known limitations

- In-memory storage, lost on server restart.
- Owner check is a placeholder via the `X-Owner-Pubkey` header; a proper Ed25519 challenge-response signature will replace it.
- The 24h queue TTL is declared but the cleanup goroutine is not yet implemented.