### PR TITLE
feat(server): persistent storage + Ed25519 challenge-response auth

### DIFF
--- a/server/cmd/moldd/main.go
+++ b/server/cmd/moldd/main.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	v1 "github.com/WissCore/moldchat/server/internal/api/v1"
+	"github.com/WissCore/moldchat/server/internal/auth"
 	"github.com/WissCore/moldchat/server/internal/health"
 	"github.com/WissCore/moldchat/server/internal/storage"
 	"github.com/WissCore/moldchat/server/internal/storage/cleanup"
@@ -53,7 +54,7 @@ func run() int {
 	mux := http.NewServeMux()
 	mux.Handle("GET /healthz", health.Handler())
 
-	api := &v1.Server{Storage: store, Logger: logger}
+	api := &v1.Server{Storage: store, Auth: auth.NewIssuer(), Logger: logger}
 	api.Mount(mux)
 
 	srv := &http.Server{

--- a/server/cmd/moldd/main.go
+++ b/server/cmd/moldd/main.go
@@ -4,15 +4,16 @@
 
 // Command moldd is the MoldChat relay server.
 //
-// The current build exposes a queue HTTP API backed by in-memory storage and
-// authorises owners by constant-time comparison against the public key
-// supplied at queue creation. Sealed-sender routing, persistence, anti-spam,
-// and key transparency are not implemented yet.
+// The current build exposes a queue HTTP API. Storage backend is selected via
+// the MOLDD_STORAGE environment variable: "memory" (the default, ephemeral)
+// or "sqlite" (persistent, encrypted with SQLCipher and an HKDF-derived key
+// per queue, requires MOLDD_MASTER_SEED and MOLDD_DATA_DIR).
 package main
 
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -22,13 +23,17 @@ import (
 
 	v1 "github.com/WissCore/moldchat/server/internal/api/v1"
 	"github.com/WissCore/moldchat/server/internal/health"
+	"github.com/WissCore/moldchat/server/internal/storage"
+	"github.com/WissCore/moldchat/server/internal/storage/cleanup"
 	"github.com/WissCore/moldchat/server/internal/storage/memory"
+	"github.com/WissCore/moldchat/server/internal/storage/sqlite"
 )
 
 const (
-	defaultAddr       = ":8080"
-	readHeaderTimeout = 10 * time.Second
-	shutdownTimeout   = 5 * time.Second
+	defaultAddr            = ":8080"
+	readHeaderTimeout      = 10 * time.Second
+	shutdownTimeout        = 5 * time.Second
+	defaultCleanupInterval = 5 * time.Minute
 )
 
 func main() {
@@ -36,33 +41,38 @@ func main() {
 }
 
 func run() int {
-	addr := defaultAddr
-	if v := os.Getenv("MOLDD_ADDR"); v != "" {
-		addr = v
-	}
-
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	store, closeStore, runCleanup, err := initStorage(logger)
+	if err != nil {
+		logger.Error("init storage", "err", err.Error())
+		return 1
+	}
+	defer func() { _ = closeStore() }()
 
 	mux := http.NewServeMux()
 	mux.Handle("GET /healthz", health.Handler())
 
-	api := &v1.Server{
-		Storage: memory.New(),
-		Logger:  logger,
-	}
+	api := &v1.Server{Storage: store, Logger: logger}
 	api.Mount(mux)
 
 	srv := &http.Server{
-		Addr:              addr,
+		Addr:              addr(),
 		Handler:           mux,
 		ReadHeaderTimeout: readHeaderTimeout,
 	}
 
+	rootCtx, rootCancel := context.WithCancel(context.Background())
+	defer rootCancel()
+	if runCleanup != nil {
+		go runCleanup(rootCtx)
+	}
+
 	serverErr := make(chan error, 1)
 	go func() {
-		logger.Info("moldd starting", "addr", addr)
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			serverErr <- err
+		logger.Info("moldd starting", "addr", srv.Addr)
+		if listenErr := srv.ListenAndServe(); listenErr != nil && !errors.Is(listenErr, http.ErrServerClosed) {
+			serverErr <- listenErr
 		}
 	}()
 
@@ -70,8 +80,8 @@ func run() int {
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
 	select {
-	case err := <-serverErr:
-		logger.Error("server failed", "err", err)
+	case listenErr := <-serverErr:
+		logger.Error("server failed", "err", listenErr.Error())
 		return 1
 	case sig := <-stop:
 		logger.Info("shutdown requested", "signal", sig.String())
@@ -79,10 +89,56 @@ func run() int {
 
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
-	if err := srv.Shutdown(ctx); err != nil {
-		logger.Error("graceful shutdown failed", "err", err)
+	if shutdownErr := srv.Shutdown(ctx); shutdownErr != nil {
+		logger.Error("graceful shutdown failed", "err", shutdownErr.Error())
 		return 1
 	}
 	logger.Info("moldd stopped")
 	return 0
+}
+
+func addr() string {
+	if v := os.Getenv("MOLDD_ADDR"); v != "" {
+		return v
+	}
+	return defaultAddr
+}
+
+// initStorage constructs the configured storage backend and (when persistent)
+// the cleanup-runner that evicts expired queues. The closeStore callback
+// releases backend resources; runCleanup is nil for the in-memory backend.
+func initStorage(logger *slog.Logger) (
+	store storage.Storage,
+	closeStore func() error,
+	runCleanup func(context.Context),
+	err error,
+) {
+	switch backend := os.Getenv("MOLDD_STORAGE"); backend {
+	case "", "memory":
+		mem := memory.New()
+		return mem, func() error { return nil }, nil, nil
+
+	case "sqlite":
+		seed, seedErr := sqlite.LoadMasterSeed()
+		if seedErr != nil {
+			return nil, nil, nil, fmt.Errorf("sqlite backend: %w", seedErr)
+		}
+		dataDir := os.Getenv("MOLDD_DATA_DIR")
+		if dataDir == "" {
+			return nil, nil, nil, errors.New("sqlite backend: MOLDD_DATA_DIR is required")
+		}
+		st, openErr := sqlite.New(seed, dataDir)
+		if openErr != nil {
+			return nil, nil, nil, fmt.Errorf("sqlite backend: %w", openErr)
+		}
+		runner := &cleanup.Runner{
+			Cleaner:  st,
+			Interval: defaultCleanupInterval,
+			Logger:   logger,
+		}
+		return st, st.Close, runner.Run, nil
+
+	default:
+		return nil, nil, nil, fmt.Errorf("unknown MOLDD_STORAGE backend: %q (valid: memory, sqlite)", backend)
+	}
 }

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,3 +1,8 @@
 module github.com/WissCore/moldchat/server
 
 go 1.26.2
+
+require (
+	github.com/mutecomm/go-sqlcipher/v4 v4.4.2
+	golang.org/x/crypto v0.50.0
+)

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/mutecomm/go-sqlcipher/v4 v4.4.2 h1:eM10bFtI4UvibIsKr10/QT7Yfz+NADfjZYh0GKrXUNc=
+github.com/mutecomm/go-sqlcipher/v4 v4.4.2/go.mod h1:mF2UmIpBnzFeBdu/ypTDb/LdbS0nk0dfSN1WUsWTjMA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
+golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=

--- a/server/internal/api/v1/api.go
+++ b/server/internal/api/v1/api.go
@@ -6,32 +6,55 @@
 //
 // Endpoints:
 //
-//	POST   /v1/queues                       - create a queue
-//	PUT    /v1/queues/{id}/messages          - append a blob
-//	GET    /v1/queues/{id}/messages          - list pending messages (owner-only)
-//	DELETE /v1/queues/{id}/messages/{mid}    - delete a message (owner-only)
+//	POST   /v1/queues                          - create a queue
+//	GET    /v1/queues/{id}/auth-challenge       - request a fresh nonce
+//	PUT    /v1/queues/{id}/messages             - append a blob (unauth)
+//	GET    /v1/queues/{id}/messages             - list pending messages (owner-only)
+//	DELETE /v1/queues/{id}/messages/{mid}       - delete a message (owner-only)
 //
-// Owner-only operations are authorised by a constant-time comparison against
-// the public key supplied at queue creation. This is a placeholder; a proper
-// Ed25519 challenge-response signature will replace it.
+// Owner-only operations are authorised by an Ed25519 challenge-response
+// signature: the client requests a nonce, signs (nonce, queue_id, method,
+// path) with the private key whose public half was registered at queue
+// creation, and presents the signature in an Authorization header. See
+// the auth package for the canonical payload format and replay protection.
 package v1
 
 import (
 	"log/slog"
 	"net/http"
+	"sync/atomic"
 
+	"github.com/WissCore/moldchat/server/internal/auth"
 	"github.com/WissCore/moldchat/server/internal/storage"
 )
 
-// Server holds dependencies shared by handlers.
+// Server holds dependencies shared by handlers. Storage and Auth must be
+// initialised before Mount is called; Logger is optional.
+//
+// AuthFailureCount is incremented for every owner-only request that fails
+// authorisation, regardless of cause (missing header, malformed payload,
+// unknown queue, wrong key, expired or replayed nonce, bad signature).
+// Returning a single boolean to clients while keeping a server-side
+// aggregate avoids leaking which check failed and supports later
+// integration with the L8 forward-secure counter pipeline.
 type Server struct {
-	Storage storage.Storage
-	Logger  *slog.Logger
+	Storage          storage.Storage
+	Auth             *auth.Issuer
+	Logger           *slog.Logger
+	AuthFailureCount atomic.Uint64
 }
 
-// Mount registers the v1 routes on the supplied mux.
+// Mount registers the v1 routes on the supplied mux. Storage and Auth
+// must already be set; Mount panics otherwise to fail loudly at startup.
 func (s *Server) Mount(mux *http.ServeMux) {
+	if s.Storage == nil {
+		panic("v1.Server.Storage must be set before Mount")
+	}
+	if s.Auth == nil {
+		panic("v1.Server.Auth must be set before Mount")
+	}
 	mux.Handle("POST /v1/queues", s.handleCreateQueue())
+	mux.Handle("GET /v1/queues/{id}/auth-challenge", s.handleAuthChallenge())
 	mux.Handle("PUT /v1/queues/{id}/messages", s.handlePutMessage())
 	mux.Handle("GET /v1/queues/{id}/messages", s.handleListMessages())
 	mux.Handle("DELETE /v1/queues/{id}/messages/{mid}", s.handleDeleteMessage())

--- a/server/internal/api/v1/queues.go
+++ b/server/internal/api/v1/queues.go
@@ -5,6 +5,7 @@
 package v1
 
 import (
+	"crypto/ed25519"
 	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
@@ -13,15 +14,22 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/WissCore/moldchat/server/internal/auth"
 	"github.com/WissCore/moldchat/server/internal/queue"
 )
+
+// errAuthDenied is returned by authorizeOwner for any reason an owner-only
+// request is rejected. The cause is intentionally not surfaced to the
+// client, but it bumps the AuthFailureCount counter on Server.
+var errAuthDenied = errors.New("authorization denied")
 
 // maxCreateBody bounds the JSON body for queue-creation requests.
 const maxCreateBody = 4 * 1024
 
 func (s *Server) handleCreateQueue() http.Handler {
 	type request struct {
-		OwnerPubkey string `json:"owner_pubkey"`
+		OwnerX25519Pubkey  string `json:"owner_x25519_pubkey"`
+		OwnerEd25519Pubkey string `json:"owner_ed25519_pubkey"`
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, maxCreateBody)
@@ -33,14 +41,20 @@ func (s *Server) handleCreateQueue() http.Handler {
 			writeError(w, http.StatusBadRequest, "invalid json body")
 			return
 		}
-		key, err := base64.StdEncoding.DecodeString(req.OwnerPubkey)
+		x25519Key, err := base64.StdEncoding.DecodeString(req.OwnerX25519Pubkey)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "owner_pubkey must be base64-encoded")
+			writeError(w, http.StatusBadRequest, "owner_x25519_pubkey must be base64-encoded")
 			return
 		}
-		q, err := s.Storage.CreateQueue(r.Context(), key)
+		ed25519Key, err := base64.StdEncoding.DecodeString(req.OwnerEd25519Pubkey)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "owner_ed25519_pubkey must be base64-encoded")
+			return
+		}
+		keys := queue.OwnerKeys{X25519Pub: x25519Key, Ed25519Pub: ed25519Key}
+		q, err := s.Storage.CreateQueue(r.Context(), keys)
 		switch {
-		case errors.Is(err, queue.ErrInvalidOwnerKey):
+		case errors.Is(err, queue.ErrInvalidX25519Key), errors.Is(err, queue.ErrInvalidEd25519Key):
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
 		case err != nil:
@@ -51,6 +65,35 @@ func (s *Server) handleCreateQueue() http.Handler {
 		writeJSON(w, http.StatusCreated, map[string]any{
 			"queue_id":   q.ID,
 			"expires_at": q.ExpiresAt.Format(time.RFC3339),
+		})
+	})
+}
+
+func (s *Server) handleAuthChallenge() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queueID := r.PathValue("id")
+		if _, err := s.Storage.GetQueue(r.Context(), queueID); err != nil {
+			if errors.Is(err, queue.ErrQueueNotFound) {
+				writeError(w, http.StatusNotFound, "queue not found")
+				return
+			}
+			s.logServerError("get queue", err)
+			writeError(w, http.StatusInternalServerError, "internal error")
+			return
+		}
+		nonce, expiresAt, err := s.Auth.Issue()
+		switch {
+		case errors.Is(err, auth.ErrIssuerSaturated):
+			writeError(w, http.StatusServiceUnavailable, "too many outstanding challenges")
+			return
+		case err != nil:
+			s.logServerError("issue nonce", err)
+			writeError(w, http.StatusInternalServerError, "internal error")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"nonce":      base64.StdEncoding.EncodeToString(nonce),
+			"expires_at": expiresAt.Format(time.RFC3339),
 		})
 	})
 }
@@ -109,7 +152,8 @@ func (s *Server) handleListMessages() http.Handler {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
-		if !s.authorizeOwner(r, q) {
+		if authErr := s.authorizeOwner(r, q); authErr != nil {
+			s.AuthFailureCount.Add(1)
 			writeError(w, http.StatusUnauthorized, "unauthorized")
 			return
 		}
@@ -149,7 +193,8 @@ func (s *Server) handleDeleteMessage() http.Handler {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
-		if !s.authorizeOwner(r, q) {
+		if authErr := s.authorizeOwner(r, q); authErr != nil {
+			s.AuthFailureCount.Add(1)
 			writeError(w, http.StatusUnauthorized, "unauthorized")
 			return
 		}
@@ -167,19 +212,27 @@ func (s *Server) handleDeleteMessage() http.Handler {
 	})
 }
 
-// authorizeOwner compares the X-Owner-Pubkey header (base64-encoded 32 bytes)
-// against the key supplied at queue creation, in constant time. This is a
-// placeholder for a proper Ed25519 challenge-response signature.
-func (s *Server) authorizeOwner(r *http.Request, q *queue.Queue) bool {
-	header := r.Header.Get("X-Owner-Pubkey")
-	if header == "" {
-		return false
-	}
-	key, err := base64.StdEncoding.DecodeString(header)
+// authorizeOwner verifies the Ed25519-Sig challenge-response in the
+// Authorization header against the queue's registered owner public key.
+// It returns nil on success and errAuthDenied for every failure mode;
+// the cause is intentionally collapsed so the response does not reveal
+// which check failed.
+func (s *Server) authorizeOwner(r *http.Request, q *queue.Queue) error {
+	sig, pubkey, nonce, err := auth.ParseAuthorization(r.Header.Get("Authorization"))
 	if err != nil {
-		return false
+		return errAuthDenied
 	}
-	return subtle.ConstantTimeCompare(key, q.OwnerKey) == 1
+	if subtle.ConstantTimeCompare(pubkey, q.OwnerEd25519Pub) != 1 {
+		return errAuthDenied
+	}
+	if verifyErr := s.Auth.Verify(
+		ed25519.PublicKey(pubkey),
+		nonce, sig,
+		q.ID, r.Method, r.URL.Path,
+	); verifyErr != nil {
+		return errAuthDenied
+	}
+	return nil
 }
 
 func (s *Server) logServerError(op string, err error) {

--- a/server/internal/api/v1/queues_test.go
+++ b/server/internal/api/v1/queues_test.go
@@ -6,36 +6,57 @@ package v1_test
 
 import (
 	"bytes"
+	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
 	v1 "github.com/WissCore/moldchat/server/internal/api/v1"
+	"github.com/WissCore/moldchat/server/internal/auth"
 	"github.com/WissCore/moldchat/server/internal/queue"
 	"github.com/WissCore/moldchat/server/internal/storage/memory"
 )
 
-func newTestServer(t *testing.T) *httptest.Server {
-	t.Helper()
-	mux := http.NewServeMux()
-	(&v1.Server{Storage: memory.New()}).Mount(mux)
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-	return srv
+type ownerCreds struct {
+	x25519Pub  []byte
+	ed25519Pub ed25519.PublicKey
+	ed25519Pri ed25519.PrivateKey
 }
 
-func randomOwnerKey(t *testing.T) (raw []byte, b64 string) {
+// testServer pairs the underlying *v1.Server with its httptest fixture so
+// tests can both hit the API and observe internal counters.
+type testServer struct {
+	*httptest.Server
+	api *v1.Server
+}
+
+func newTestServer(t *testing.T) *testServer {
 	t.Helper()
-	raw = make([]byte, queue.OwnerKeyBytes)
-	if _, err := rand.Read(raw); err != nil {
-		t.Fatalf("rand: %v", err)
+	mux := http.NewServeMux()
+	api := &v1.Server{Storage: memory.New(), Auth: auth.NewIssuer()}
+	api.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return &testServer{Server: srv, api: api}
+}
+
+func newOwner(t *testing.T) ownerCreds {
+	t.Helper()
+	x := make([]byte, queue.X25519PubKeyBytes)
+	if _, err := rand.Read(x); err != nil {
+		t.Fatalf("rand x25519: %v", err)
 	}
-	return raw, base64.StdEncoding.EncodeToString(raw)
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519: %v", err)
+	}
+	return ownerCreds{x25519Pub: x, ed25519Pub: pub, ed25519Pri: priv}
 }
 
 func decodeJSON(t *testing.T, body io.Reader, dst any) {
@@ -60,10 +81,14 @@ func putBlob(t *testing.T, url string, body io.Reader) *http.Response {
 	return resp
 }
 
-func createQueue(t *testing.T, baseURL, ownerB64 string) string {
+func createQueue(t *testing.T, baseURL string, owner ownerCreds) string {
 	t.Helper()
-	resp, err := http.Post(baseURL+"/v1/queues", "application/json",
-		strings.NewReader(`{"owner_pubkey":"`+ownerB64+`"}`))
+	body := map[string]string{
+		"owner_x25519_pubkey":  base64.StdEncoding.EncodeToString(owner.x25519Pub),
+		"owner_ed25519_pubkey": base64.StdEncoding.EncodeToString(owner.ed25519Pub),
+	}
+	raw, _ := json.Marshal(body)
+	resp, err := http.Post(baseURL+"/v1/queues", "application/json", bytes.NewReader(raw))
 	if err != nil {
 		t.Fatalf("create queue: %v", err)
 	}
@@ -78,13 +103,58 @@ func createQueue(t *testing.T, baseURL, ownerB64 string) string {
 	return got.QueueID
 }
 
+// fetchNonce calls GET /auth-challenge and returns the raw nonce bytes.
+func fetchNonce(t *testing.T, baseURL, queueID string) []byte {
+	t.Helper()
+	resp, err := http.Get(baseURL + "/v1/queues/" + queueID + "/auth-challenge")
+	if err != nil {
+		t.Fatalf("auth-challenge: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("auth-challenge status: %d", resp.StatusCode)
+	}
+	var got struct {
+		Nonce string `json:"nonce"`
+	}
+	decodeJSON(t, resp.Body, &got)
+	nonce, err := base64.StdEncoding.DecodeString(got.Nonce)
+	if err != nil {
+		t.Fatalf("decode nonce: %v", err)
+	}
+	return nonce
+}
+
+// signedRequest builds a request authenticated with a fresh challenge.
+func signedRequest(t *testing.T, baseURL, queueID, method, target string, owner ownerCreds) *http.Request {
+	t.Helper()
+	nonce := fetchNonce(t, baseURL, queueID)
+	u, err := url.Parse(baseURL + target)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	payload := auth.CanonicalPayload(nonce, queueID, method, u.Path)
+	sig := ed25519.Sign(owner.ed25519Pri, payload)
+
+	req, err := http.NewRequest(method, baseURL+target, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", auth.FormatAuthorization(sig, owner.ed25519Pub, nonce))
+	return req
+}
+
 func TestCreateQueue_Happy(t *testing.T) {
 	t.Parallel()
 	srv := newTestServer(t)
-	_, b64 := randomOwnerKey(t)
+	owner := newOwner(t)
 
-	resp, err := http.Post(srv.URL+"/v1/queues", "application/json",
-		strings.NewReader(`{"owner_pubkey":"`+b64+`"}`))
+	body := map[string]string{
+		"owner_x25519_pubkey":  base64.StdEncoding.EncodeToString(owner.x25519Pub),
+		"owner_ed25519_pubkey": base64.StdEncoding.EncodeToString(owner.ed25519Pub),
+	}
+	raw, _ := json.Marshal(body)
+	resp, err := http.Post(srv.URL+"/v1/queues", "application/json", bytes.NewReader(raw))
 	if err != nil {
 		t.Fatalf("post: %v", err)
 	}
@@ -107,8 +177,12 @@ func TestCreateQueue_InvalidKeyLength(t *testing.T) {
 	t.Parallel()
 	srv := newTestServer(t)
 
-	body := strings.NewReader(`{"owner_pubkey":"` + base64.StdEncoding.EncodeToString([]byte("short")) + `"}`)
-	resp, err := http.Post(srv.URL+"/v1/queues", "application/json", body)
+	body := map[string]string{
+		"owner_x25519_pubkey":  base64.StdEncoding.EncodeToString([]byte("short")),
+		"owner_ed25519_pubkey": base64.StdEncoding.EncodeToString(make([]byte, 32)),
+	}
+	raw, _ := json.Marshal(body)
+	resp, err := http.Post(srv.URL+"/v1/queues", "application/json", bytes.NewReader(raw))
 	if err != nil {
 		t.Fatalf("post: %v", err)
 	}
@@ -122,8 +196,8 @@ func TestCreateQueue_InvalidKeyLength(t *testing.T) {
 func TestPutMessage_RoundTrip(t *testing.T) {
 	t.Parallel()
 	srv := newTestServer(t)
-	rawKey, b64 := randomOwnerKey(t)
-	queueID := createQueue(t, srv.URL, b64)
+	owner := newOwner(t)
+	queueID := createQueue(t, srv.URL, owner)
 
 	blob := []byte("opaque-blob-content")
 	putResp := putBlob(t, srv.URL+"/v1/queues/"+queueID+"/messages", bytes.NewReader(blob))
@@ -132,11 +206,8 @@ func TestPutMessage_RoundTrip(t *testing.T) {
 		t.Fatalf("PUT status: got %d, want 202", putResp.StatusCode)
 	}
 
-	req, err := http.NewRequest(http.MethodGet, srv.URL+"/v1/queues/"+queueID+"/messages", nil)
-	if err != nil {
-		t.Fatalf("new get: %v", err)
-	}
-	req.Header.Set("X-Owner-Pubkey", base64.StdEncoding.EncodeToString(rawKey))
+	req := signedRequest(t, srv.URL, queueID, http.MethodGet,
+		"/v1/queues/"+queueID+"/messages", owner)
 	getResp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("get: %v", err)
@@ -180,8 +251,8 @@ func TestPutMessage_QueueNotFound(t *testing.T) {
 func TestPutMessage_TooLarge(t *testing.T) {
 	t.Parallel()
 	srv := newTestServer(t)
-	_, b64 := randomOwnerKey(t)
-	queueID := createQueue(t, srv.URL, b64)
+	owner := newOwner(t)
+	queueID := createQueue(t, srv.URL, owner)
 
 	resp := putBlob(t, srv.URL+"/v1/queues/"+queueID+"/messages",
 		bytes.NewReader(make([]byte, queue.MaxBlobSize+1)))
@@ -194,39 +265,82 @@ func TestPutMessage_TooLarge(t *testing.T) {
 func TestListMessages_Unauthorized(t *testing.T) {
 	t.Parallel()
 	srv := newTestServer(t)
-	_, b64 := randomOwnerKey(t)
-	queueID := createQueue(t, srv.URL, b64)
+	owner := newOwner(t)
+	queueID := createQueue(t, srv.URL, owner)
 
-	noKeyResp, err := http.Get(srv.URL + "/v1/queues/" + queueID + "/messages")
+	noAuthResp, err := http.Get(srv.URL + "/v1/queues/" + queueID + "/messages")
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	defer func() { _ = noKeyResp.Body.Close() }()
-	if noKeyResp.StatusCode != http.StatusUnauthorized {
-		t.Errorf("no auth: got %d, want 401", noKeyResp.StatusCode)
+	defer func() { _ = noAuthResp.Body.Close() }()
+	if noAuthResp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("no auth: got %d, want 401", noAuthResp.StatusCode)
 	}
 
-	wrongKey, _ := randomOwnerKey(t)
-	req, err := http.NewRequest(http.MethodGet, srv.URL+"/v1/queues/"+queueID+"/messages", nil)
-	if err != nil {
-		t.Fatalf("new get: %v", err)
-	}
-	req.Header.Set("X-Owner-Pubkey", base64.StdEncoding.EncodeToString(wrongKey))
-	wrongKeyResp, err := http.DefaultClient.Do(req)
+	intruder := newOwner(t)
+	req := signedRequest(t, srv.URL, queueID, http.MethodGet,
+		"/v1/queues/"+queueID+"/messages", intruder)
+	wrongResp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("do: %v", err)
 	}
-	defer func() { _ = wrongKeyResp.Body.Close() }()
-	if wrongKeyResp.StatusCode != http.StatusUnauthorized {
-		t.Errorf("wrong key: got %d, want 401", wrongKeyResp.StatusCode)
+	defer func() { _ = wrongResp.Body.Close() }()
+	if wrongResp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("wrong key: got %d, want 401", wrongResp.StatusCode)
+	}
+}
+
+func TestListMessages_RejectsReplay(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+	owner := newOwner(t)
+	queueID := createQueue(t, srv.URL, owner)
+
+	req := signedRequest(t, srv.URL, queueID, http.MethodGet,
+		"/v1/queues/"+queueID+"/messages", owner)
+	first, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("first do: %v", err)
+	}
+	_ = first.Body.Close()
+	if first.StatusCode != http.StatusOK {
+		t.Fatalf("first status: %d", first.StatusCode)
+	}
+
+	// Same Authorization header, second time should be rejected.
+	replay, err := http.NewRequest(http.MethodGet, srv.URL+"/v1/queues/"+queueID+"/messages", nil)
+	if err != nil {
+		t.Fatalf("new replay: %v", err)
+	}
+	replay.Header.Set("Authorization", req.Header.Get("Authorization"))
+	replayResp, err := http.DefaultClient.Do(replay)
+	if err != nil {
+		t.Fatalf("replay do: %v", err)
+	}
+	defer func() { _ = replayResp.Body.Close() }()
+	if replayResp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("replay status: got %d, want 401", replayResp.StatusCode)
+	}
+}
+
+func TestAuthChallenge_QueueNotFound(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+	resp, err := http.Get(srv.URL + "/v1/queues/MISSING/auth-challenge")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: got %d, want 404", resp.StatusCode)
 	}
 }
 
 func TestDeleteMessage_RoundTrip(t *testing.T) {
 	t.Parallel()
 	srv := newTestServer(t)
-	rawKey, b64 := randomOwnerKey(t)
-	queueID := createQueue(t, srv.URL, b64)
+	owner := newOwner(t)
+	queueID := createQueue(t, srv.URL, owner)
 
 	putResp := putBlob(t, srv.URL+"/v1/queues/"+queueID+"/messages", strings.NewReader("payload"))
 	var puts struct {
@@ -235,11 +349,8 @@ func TestDeleteMessage_RoundTrip(t *testing.T) {
 	decodeJSON(t, putResp.Body, &puts)
 	_ = putResp.Body.Close()
 
-	req, err := http.NewRequest(http.MethodDelete, srv.URL+"/v1/queues/"+queueID+"/messages/"+puts.MessageID, nil)
-	if err != nil {
-		t.Fatalf("new delete: %v", err)
-	}
-	req.Header.Set("X-Owner-Pubkey", base64.StdEncoding.EncodeToString(rawKey))
+	req := signedRequest(t, srv.URL, queueID, http.MethodDelete,
+		"/v1/queues/"+queueID+"/messages/"+puts.MessageID, owner)
 	delResp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("delete: %v", err)
@@ -247,5 +358,94 @@ func TestDeleteMessage_RoundTrip(t *testing.T) {
 	defer func() { _ = delResp.Body.Close() }()
 	if delResp.StatusCode != http.StatusNoContent {
 		t.Errorf("DELETE status: got %d, want 204", delResp.StatusCode)
+	}
+}
+
+// TestListMessages_RejectsTamperedMethod proves that a signature produced
+// for one HTTP method cannot authorise another. The client signs payload
+// with method GET, then submits the signed Authorization header on a
+// DELETE request; the server must reject it.
+func TestListMessages_RejectsTamperedMethod(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+	owner := newOwner(t)
+	queueID := createQueue(t, srv.URL, owner)
+
+	putResp := putBlob(t, srv.URL+"/v1/queues/"+queueID+"/messages", strings.NewReader("payload"))
+	var puts struct {
+		MessageID string `json:"message_id"`
+	}
+	decodeJSON(t, putResp.Body, &puts)
+	_ = putResp.Body.Close()
+
+	// Sign for GET, submit as DELETE.
+	req := signedRequest(t, srv.URL, queueID, http.MethodGet,
+		"/v1/queues/"+queueID+"/messages/"+puts.MessageID, owner)
+	req.Method = http.MethodDelete
+	req.URL.Path = "/v1/queues/" + queueID + "/messages/" + puts.MessageID
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want 401", resp.StatusCode)
+	}
+}
+
+// TestListMessages_MalformedAuthorizationHeader covers the API-level
+// surface for headers that don't even parse: garbage, wrong scheme,
+// invalid base64. All must collapse to 401 (not 400) so we don't leak
+// which validation step rejected the request.
+func TestListMessages_MalformedAuthorizationHeader(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+	owner := newOwner(t)
+	queueID := createQueue(t, srv.URL, owner)
+
+	cases := []string{
+		"garbage",
+		"Bearer abc",
+		"ED25519-Sig only-one-part",
+		"ED25519-Sig !!!,!!!,!!!",
+	}
+	for _, header := range cases {
+		t.Run(header, func(t *testing.T) {
+			t.Parallel()
+			req, err := http.NewRequest(http.MethodGet, srv.URL+"/v1/queues/"+queueID+"/messages", nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			req.Header.Set("Authorization", header)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("do: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Errorf("got %d, want 401", resp.StatusCode)
+			}
+		})
+	}
+}
+
+// TestAuthFailureCount_BumpsOnDenial verifies the server-side aggregate
+// counter is incremented on auth failure.
+func TestAuthFailureCount_BumpsOnDenial(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+	owner := newOwner(t)
+	queueID := createQueue(t, srv.URL, owner)
+
+	before := srv.api.AuthFailureCount.Load()
+	resp, err := http.Get(srv.URL + "/v1/queues/" + queueID + "/messages")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if got := srv.api.AuthFailureCount.Load(); got != before+1 {
+		t.Errorf("counter: got %d, want %d", got, before+1)
 	}
 }

--- a/server/internal/auth/auth.go
+++ b/server/internal/auth/auth.go
@@ -1,0 +1,210 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package auth implements challenge-response authentication for queue
+// owner-only operations.
+//
+// Flow:
+//
+//  1. Client requests GET /v1/queues/{id}/auth-challenge.
+//     Server returns a fresh 32-byte nonce with a 30-second TTL.
+//  2. Client signs the canonical payload
+//     "moldd-v1-auth" || 0x00 || nonce || 0x00 || queue_id || 0x00 ||
+//     method || 0x00 || path
+//     using the Ed25519 private key whose public half was registered when
+//     the queue was created.
+//  3. Client sends the request with header
+//     Authorization: ED25519-Sig <signature_b64>,<pubkey_b64>,<nonce_b64>
+//     The header format is comma-separated bare base64 fields rather than
+//     the auth-params syntax of RFC 7235; we deliberately keep it compact
+//     because every byte of an authenticated request matters and the scheme
+//     is private to MoldChat clients.
+//  4. Server re-derives the canonical payload, checks the supplied pubkey
+//     matches the one registered with the queue (constant-time), verifies
+//     the signature, and burns the nonce so it cannot be replayed.
+//
+// The nonce store is in-memory, has a hard cap on outstanding entries,
+// and is GCed lazily on each Issue call.
+package auth
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Sizing and TTLs for challenge nonces.
+const (
+	NonceBytes = 32
+	NonceTTL   = 30 * time.Second
+	AuthScheme = "ED25519-Sig"
+
+	// MaxOutstandingNonces caps the in-memory map of issued-but-not-yet-used
+	// nonces. Once reached, Issue returns ErrIssuerSaturated and the caller
+	// is expected to surface a 503 to the client. The cap protects the
+	// process against memory exhaustion when /auth-challenge is hit at a
+	// rate higher than legitimate clients require; finer-grained per-client
+	// rate limiting belongs in the L4 anti-spam layer.
+	MaxOutstandingNonces = 10_000
+
+	domainTag = "moldd-v1-auth"
+	separator = 0x00
+)
+
+// Sentinel errors returned by the auth layer.
+var (
+	ErrAuthorizationMissing   = errors.New("authorization header missing")
+	ErrAuthorizationMalformed = errors.New("authorization header malformed")
+	ErrSignatureInvalid       = errors.New("signature invalid")
+	ErrReplay                 = errors.New("nonce already used or expired")
+	ErrIssuerSaturated        = errors.New("issuer at capacity")
+)
+
+// Issuer issues nonces and verifies challenge-response signatures.
+//
+// All methods are safe for concurrent use. Memory usage is bounded by
+// MaxOutstandingNonces; expired entries are reaped lazily on each call
+// to Issue.
+type Issuer struct {
+	mu     sync.Mutex
+	issued map[string]time.Time // nonce → expires_at
+	now    func() time.Time
+}
+
+// NewIssuer returns a fresh Issuer using time.Now as its clock.
+func NewIssuer() *Issuer {
+	return &Issuer{
+		issued: make(map[string]time.Time),
+		now:    time.Now,
+	}
+}
+
+// Issue returns a fresh nonce together with its expiry timestamp.
+// The nonce is single-use and remembered until Verify consumes it or it
+// expires. Each call sweeps expired entries; if the live set is at the
+// MaxOutstandingNonces cap after sweeping, ErrIssuerSaturated is returned.
+func (i *Issuer) Issue() (nonce []byte, expiresAt time.Time, err error) {
+	nonce = make([]byte, NonceBytes)
+	if _, err = rand.Read(nonce); err != nil {
+		return nil, time.Time{}, err
+	}
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	now := i.now()
+	for k, exp := range i.issued {
+		if !exp.After(now) {
+			delete(i.issued, k)
+		}
+	}
+	if len(i.issued) >= MaxOutstandingNonces {
+		return nil, time.Time{}, ErrIssuerSaturated
+	}
+
+	expiresAt = now.Add(NonceTTL)
+	i.issued[string(nonce)] = expiresAt
+	return nonce, expiresAt, nil
+}
+
+// Verify checks the signature against pubkey for the canonical payload
+// derived from (nonce, queueID, method, path). On success the nonce is
+// burned so subsequent calls return ErrReplay. The nonce is also burned
+// on signature failure: a single nonce must never authorise more than
+// one verification attempt, regardless of outcome.
+func (i *Issuer) Verify(pubkey ed25519.PublicKey, nonce, sig []byte, queueID, method, path string) error {
+	if len(pubkey) != ed25519.PublicKeySize {
+		return ErrSignatureInvalid
+	}
+	if len(nonce) != NonceBytes {
+		return ErrAuthorizationMalformed
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return ErrAuthorizationMalformed
+	}
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	expiresAt, ok := i.issued[string(nonce)]
+	if !ok {
+		return ErrReplay
+	}
+	if !expiresAt.After(i.now()) {
+		delete(i.issued, string(nonce))
+		return ErrReplay
+	}
+
+	payload := canonicalPayload(nonce, queueID, method, path)
+	if !ed25519.Verify(pubkey, payload, sig) {
+		delete(i.issued, string(nonce))
+		return ErrSignatureInvalid
+	}
+	delete(i.issued, string(nonce))
+	return nil
+}
+
+// canonicalPayload returns the bytes that must be signed by the client.
+// The format is documented at the top of this package.
+func canonicalPayload(nonce []byte, queueID, method, path string) []byte {
+	out := make([]byte, 0, len(domainTag)+1+len(nonce)+1+len(queueID)+1+len(method)+1+len(path))
+	out = append(out, domainTag...)
+	out = append(out, separator)
+	out = append(out, nonce...)
+	out = append(out, separator)
+	out = append(out, queueID...)
+	out = append(out, separator)
+	out = append(out, method...)
+	out = append(out, separator)
+	out = append(out, path...)
+	return out
+}
+
+// CanonicalPayload exposes the canonical signing payload for clients and
+// integration tests. Callers should not mutate the returned slice.
+func CanonicalPayload(nonce []byte, queueID, method, path string) []byte {
+	return canonicalPayload(nonce, queueID, method, path)
+}
+
+// ParseAuthorization parses an "ED25519-Sig <sig_b64>,<pubkey_b64>,<nonce_b64>"
+// header into raw signature, public-key, and nonce bytes.
+func ParseAuthorization(header string) (sig, pubkey, nonce []byte, err error) {
+	if header == "" {
+		return nil, nil, nil, ErrAuthorizationMissing
+	}
+	rest, ok := strings.CutPrefix(header, AuthScheme+" ")
+	if !ok {
+		return nil, nil, nil, ErrAuthorizationMalformed
+	}
+	parts := strings.Split(rest, ",")
+	if len(parts) != 3 {
+		return nil, nil, nil, ErrAuthorizationMalformed
+	}
+	sig, err = base64.StdEncoding.DecodeString(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return nil, nil, nil, ErrAuthorizationMalformed
+	}
+	pubkey, err = base64.StdEncoding.DecodeString(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return nil, nil, nil, ErrAuthorizationMalformed
+	}
+	nonce, err = base64.StdEncoding.DecodeString(strings.TrimSpace(parts[2]))
+	if err != nil {
+		return nil, nil, nil, ErrAuthorizationMalformed
+	}
+	return sig, pubkey, nonce, nil
+}
+
+// FormatAuthorization is the inverse of ParseAuthorization, primarily for
+// client and test use.
+func FormatAuthorization(sig, pubkey, nonce []byte) string {
+	return AuthScheme + " " +
+		base64.StdEncoding.EncodeToString(sig) + "," +
+		base64.StdEncoding.EncodeToString(pubkey) + "," +
+		base64.StdEncoding.EncodeToString(nonce)
+}

--- a/server/internal/auth/auth_test.go
+++ b/server/internal/auth/auth_test.go
@@ -1,0 +1,269 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package auth_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/WissCore/moldchat/server/internal/auth"
+)
+
+func newKeypair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519 GenerateKey: %v", err)
+	}
+	return pub, priv
+}
+
+func TestIssue_LengthAndUniqueness(t *testing.T) {
+	t.Parallel()
+	iss := auth.NewIssuer()
+
+	a, _, err := iss.Issue()
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	b, _, err := iss.Issue()
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if len(a) != auth.NonceBytes || len(b) != auth.NonceBytes {
+		t.Errorf("nonce length: got %d/%d, want %d", len(a), len(b), auth.NonceBytes)
+	}
+	if string(a) == string(b) {
+		t.Error("two consecutive Issue() calls returned the same nonce")
+	}
+}
+
+func TestIssue_RejectsAtSaturation(t *testing.T) {
+	t.Parallel()
+	iss := auth.NewIssuer()
+
+	// Fill the store up to the cap. Each issued nonce sits in memory for
+	// NonceTTL; since this test runs in well under a second, none expire.
+	for i := 0; i < auth.MaxOutstandingNonces; i++ {
+		if _, _, err := iss.Issue(); err != nil {
+			t.Fatalf("Issue[%d]: %v", i, err)
+		}
+	}
+	_, _, err := iss.Issue()
+	if !errors.Is(err, auth.ErrIssuerSaturated) {
+		t.Errorf("at saturation: got %v, want ErrIssuerSaturated", err)
+	}
+}
+
+func TestVerify_HappyPath(t *testing.T) {
+	t.Parallel()
+	iss := auth.NewIssuer()
+	pub, priv := newKeypair(t)
+
+	nonce, _, err := iss.Issue()
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	queueID, method, path := "Q1", "GET", "/v1/queues/Q1/messages"
+	sig := ed25519.Sign(priv, auth.CanonicalPayload(nonce, queueID, method, path))
+
+	if err := iss.Verify(pub, nonce, sig, queueID, method, path); err != nil {
+		t.Errorf("Verify: %v", err)
+	}
+}
+
+func TestVerify_RejectsReplay(t *testing.T) {
+	t.Parallel()
+	iss := auth.NewIssuer()
+	pub, priv := newKeypair(t)
+
+	nonce, _, err := iss.Issue()
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	queueID, method, path := "Q1", "GET", "/v1/queues/Q1/messages"
+	sig := ed25519.Sign(priv, auth.CanonicalPayload(nonce, queueID, method, path))
+
+	if err := iss.Verify(pub, nonce, sig, queueID, method, path); err != nil {
+		t.Fatalf("first Verify: %v", err)
+	}
+	if err := iss.Verify(pub, nonce, sig, queueID, method, path); !errors.Is(err, auth.ErrReplay) {
+		t.Errorf("second Verify: got %v, want ErrReplay", err)
+	}
+}
+
+func TestVerify_RejectsExpiredNonce(t *testing.T) {
+	t.Parallel()
+	iss := auth.NewIssuer()
+	pub, priv := newKeypair(t)
+
+	nonce, _, err := iss.Issue()
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	auth.SetClockForTest(iss, func() time.Time { return time.Now().Add(2 * auth.NonceTTL) })
+
+	queueID, method, path := "Q1", "GET", "/v1/queues/Q1/messages"
+	sig := ed25519.Sign(priv, auth.CanonicalPayload(nonce, queueID, method, path))
+
+	if err := iss.Verify(pub, nonce, sig, queueID, method, path); !errors.Is(err, auth.ErrReplay) {
+		t.Errorf("expired nonce: got %v, want ErrReplay", err)
+	}
+}
+
+func TestVerify_RejectsForgedSignature(t *testing.T) {
+	t.Parallel()
+	iss := auth.NewIssuer()
+	pub, _ := newKeypair(t)
+	_, otherPriv := newKeypair(t)
+
+	nonce, _, err := iss.Issue()
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	queueID, method, path := "Q1", "GET", "/v1/queues/Q1/messages"
+	sig := ed25519.Sign(otherPriv, auth.CanonicalPayload(nonce, queueID, method, path))
+
+	if err := iss.Verify(pub, nonce, sig, queueID, method, path); !errors.Is(err, auth.ErrSignatureInvalid) {
+		t.Errorf("forged sig: got %v, want ErrSignatureInvalid", err)
+	}
+	// Even on signature failure the nonce is burned so it cannot be reused.
+	if err := iss.Verify(pub, nonce, sig, queueID, method, path); !errors.Is(err, auth.ErrReplay) {
+		t.Errorf("burned nonce should report replay: got %v", err)
+	}
+}
+
+func TestVerify_RejectsTamperedPayload(t *testing.T) {
+	t.Parallel()
+	iss := auth.NewIssuer()
+	pub, priv := newKeypair(t)
+
+	nonce, _, err := iss.Issue()
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	sig := ed25519.Sign(priv, auth.CanonicalPayload(nonce, "Q1", "GET", "/v1/queues/Q1/messages"))
+
+	if err := iss.Verify(pub, nonce, sig, "Q2", "GET", "/v1/queues/Q1/messages"); !errors.Is(err, auth.ErrSignatureInvalid) {
+		t.Errorf("tampered queue_id: got %v, want ErrSignatureInvalid", err)
+	}
+}
+
+func TestVerify_RejectsTamperedMethod(t *testing.T) {
+	t.Parallel()
+	iss := auth.NewIssuer()
+	pub, priv := newKeypair(t)
+
+	nonce, _, err := iss.Issue()
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	sig := ed25519.Sign(priv, auth.CanonicalPayload(nonce, "Q1", "GET", "/v1/queues/Q1/messages"))
+
+	if err := iss.Verify(pub, nonce, sig, "Q1", "DELETE", "/v1/queues/Q1/messages"); !errors.Is(err, auth.ErrSignatureInvalid) {
+		t.Errorf("tampered method: got %v, want ErrSignatureInvalid", err)
+	}
+}
+
+func TestVerify_RejectsBadLengths(t *testing.T) {
+	t.Parallel()
+	iss := auth.NewIssuer()
+	pub, _ := newKeypair(t)
+
+	if err := iss.Verify(pub, []byte("short-nonce"), make([]byte, ed25519.SignatureSize), "Q", "GET", "/x"); !errors.Is(err, auth.ErrAuthorizationMalformed) {
+		t.Errorf("short nonce: got %v, want ErrAuthorizationMalformed", err)
+	}
+	if err := iss.Verify(pub, make([]byte, auth.NonceBytes), []byte("short-sig"), "Q", "GET", "/x"); !errors.Is(err, auth.ErrAuthorizationMalformed) {
+		t.Errorf("short sig: got %v, want ErrAuthorizationMalformed", err)
+	}
+}
+
+func TestParseAuthorization_RoundTrip(t *testing.T) {
+	t.Parallel()
+	sig := make([]byte, ed25519.SignatureSize)
+	pubkey := make([]byte, ed25519.PublicKeySize)
+	nonce := make([]byte, auth.NonceBytes)
+	for i := range sig {
+		sig[i] = byte(i)
+	}
+	for i := range pubkey {
+		pubkey[i] = byte(i + 50)
+	}
+	for i := range nonce {
+		nonce[i] = byte(i + 100)
+	}
+	header := auth.FormatAuthorization(sig, pubkey, nonce)
+	gotSig, gotPub, gotNonce, err := auth.ParseAuthorization(header)
+	if err != nil {
+		t.Fatalf("ParseAuthorization: %v", err)
+	}
+	if string(gotSig) != string(sig) || string(gotPub) != string(pubkey) || string(gotNonce) != string(nonce) {
+		t.Errorf("round-trip mismatch")
+	}
+}
+
+func TestParseAuthorization_RejectsMalformed(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		header string
+		want   error
+	}{
+		{"empty", "", auth.ErrAuthorizationMissing},
+		{"wrong-scheme", "Bearer abc", auth.ErrAuthorizationMalformed},
+		{"missing-comma", "ED25519-Sig abcdef", auth.ErrAuthorizationMalformed},
+		{"two-parts-only", "ED25519-Sig YWFh,YmJi", auth.ErrAuthorizationMalformed},
+		{"too-many-parts", "ED25519-Sig a,b,c,d", auth.ErrAuthorizationMalformed},
+		{"bad-base64-sig", "ED25519-Sig !!!,YWFh,YmJi", auth.ErrAuthorizationMalformed},
+		{"bad-base64-pub", "ED25519-Sig YWFh,!!!,YmJi", auth.ErrAuthorizationMalformed},
+		{"bad-base64-nonce", "ED25519-Sig YWFh,YmJi,!!!", auth.ErrAuthorizationMalformed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, _, err := auth.ParseAuthorization(tc.header)
+			if !errors.Is(err, tc.want) {
+				t.Errorf("got %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestIssuer_ConcurrentIssueAndVerify exercises the issuer under heavy
+// parallel use and lets the race detector verify there are no data races.
+func TestIssuer_ConcurrentIssueAndVerify(t *testing.T) {
+	t.Parallel()
+	iss := auth.NewIssuer()
+	pub, priv := newKeypair(t)
+
+	const goroutines = 64
+	const perGoroutine = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				nonce, _, err := iss.Issue()
+				if err != nil {
+					t.Errorf("Issue: %v", err)
+					return
+				}
+				payload := auth.CanonicalPayload(nonce, "Q", "GET", "/x")
+				sig := ed25519.Sign(priv, payload)
+				if err := iss.Verify(pub, nonce, sig, "Q", "GET", "/x"); err != nil {
+					t.Errorf("Verify: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/server/internal/auth/export_test.go
+++ b/server/internal/auth/export_test.go
@@ -1,0 +1,14 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package auth
+
+import "time"
+
+// SetClockForTest replaces the issuer's clock. Test-only.
+func SetClockForTest(i *Issuer, clock func() time.Time) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.now = clock
+}

--- a/server/internal/queue/queue.go
+++ b/server/internal/queue/queue.go
@@ -10,10 +10,13 @@
 package queue
 
 import (
+	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base32"
 	"errors"
 	"time"
+
+	"golang.org/x/crypto/curve25519"
 )
 
 // Sizing and limits for queues and messages.
@@ -21,28 +24,40 @@ const (
 	queueIDBytes   = 20
 	messageIDBytes = 16
 
-	OwnerKeyBytes = 32
-	DefaultTTL    = 24 * time.Hour
-	MaxBlobSize   = 64 * 1024
+	X25519PubKeyBytes  = curve25519.PointSize
+	Ed25519PubKeyBytes = ed25519.PublicKeySize
+	DefaultTTL         = 24 * time.Hour
+	MaxBlobSize        = 64 * 1024
 )
 
 // Sentinel errors returned by the storage and API layers.
 var (
-	ErrQueueNotFound   = errors.New("queue not found")
-	ErrMessageNotFound = errors.New("message not found")
-	ErrUnauthorized    = errors.New("unauthorized")
-	ErrBlobTooLarge    = errors.New("blob exceeds maximum size")
-	ErrEmptyBlob       = errors.New("blob is empty")
-	ErrInvalidOwnerKey = errors.New("owner key must be 32 bytes")
+	ErrQueueNotFound     = errors.New("queue not found")
+	ErrMessageNotFound   = errors.New("message not found")
+	ErrUnauthorized      = errors.New("unauthorized")
+	ErrBlobTooLarge      = errors.New("blob exceeds maximum size")
+	ErrEmptyBlob         = errors.New("blob is empty")
+	ErrInvalidX25519Key  = errors.New("x25519 public key must be 32 bytes")
+	ErrInvalidEd25519Key = errors.New("ed25519 public key must be 32 bytes")
 )
+
+// OwnerKeys is the pair of public keys registered with a queue at creation
+// time. X25519Pub is reserved for future Diffie-Hellman use (sealed-sender,
+// per-queue ECDH); Ed25519Pub authenticates owner-only operations through a
+// challenge-response signature.
+type OwnerKeys struct {
+	X25519Pub  []byte
+	Ed25519Pub []byte
+}
 
 // Queue is the metadata for an opaque message mailbox.
 type Queue struct {
-	ID         string
-	OwnerKey   []byte
-	CreatedAt  time.Time
-	ExpiresAt  time.Time
-	LastAccess time.Time
+	ID              string
+	OwnerX25519Pub  []byte
+	OwnerEd25519Pub []byte
+	CreatedAt       time.Time
+	ExpiresAt       time.Time
+	LastAccess      time.Time
 }
 
 // Message is a single blob stored in a queue.
@@ -70,10 +85,14 @@ func generateID(n int) (string, error) {
 	return idEncoding.EncodeToString(buf), nil
 }
 
-// ValidateOwnerKey rejects keys whose length differs from OwnerKeyBytes.
-func ValidateOwnerKey(key []byte) error {
-	if len(key) != OwnerKeyBytes {
-		return ErrInvalidOwnerKey
+// ValidateOwnerKeys rejects key pairs whose lengths do not match the
+// expected sizes for X25519 and Ed25519 public keys.
+func ValidateOwnerKeys(k OwnerKeys) error {
+	if len(k.X25519Pub) != X25519PubKeyBytes {
+		return ErrInvalidX25519Key
+	}
+	if len(k.Ed25519Pub) != Ed25519PubKeyBytes {
+		return ErrInvalidEd25519Key
 	}
 	return nil
 }

--- a/server/internal/queue/queue_test.go
+++ b/server/internal/queue/queue_test.go
@@ -5,6 +5,7 @@
 package queue_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/WissCore/moldchat/server/internal/queue"
@@ -41,16 +42,30 @@ func TestNewMessageID_Length(t *testing.T) {
 	}
 }
 
-func TestValidateOwnerKey(t *testing.T) {
+func TestValidateOwnerKeys(t *testing.T) {
 	t.Parallel()
 
-	if err := queue.ValidateOwnerKey(make([]byte, 32)); err != nil {
-		t.Errorf("32-byte key rejected: %v", err)
+	good := queue.OwnerKeys{
+		X25519Pub:  make([]byte, queue.X25519PubKeyBytes),
+		Ed25519Pub: make([]byte, queue.Ed25519PubKeyBytes),
 	}
-	if err := queue.ValidateOwnerKey(make([]byte, 31)); err == nil {
-		t.Error("31-byte key was not rejected")
+	if err := queue.ValidateOwnerKeys(good); err != nil {
+		t.Errorf("valid pair rejected: %v", err)
 	}
-	if err := queue.ValidateOwnerKey(nil); err == nil {
-		t.Error("nil key was not rejected")
+
+	shortX := good
+	shortX.X25519Pub = make([]byte, 31)
+	if err := queue.ValidateOwnerKeys(shortX); !errors.Is(err, queue.ErrInvalidX25519Key) {
+		t.Errorf("short X25519: got %v, want ErrInvalidX25519Key", err)
+	}
+
+	shortEd := good
+	shortEd.Ed25519Pub = make([]byte, 31)
+	if err := queue.ValidateOwnerKeys(shortEd); !errors.Is(err, queue.ErrInvalidEd25519Key) {
+		t.Errorf("short Ed25519: got %v, want ErrInvalidEd25519Key", err)
+	}
+
+	if err := queue.ValidateOwnerKeys(queue.OwnerKeys{}); !errors.Is(err, queue.ErrInvalidX25519Key) {
+		t.Errorf("empty pair: got %v, want ErrInvalidX25519Key", err)
 	}
 }

--- a/server/internal/storage/cleanup/cleanup.go
+++ b/server/internal/storage/cleanup/cleanup.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package cleanup runs periodic deletion of expired queues from a Cleaner.
+package cleanup
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/WissCore/moldchat/server/internal/queue"
+)
+
+// Cleaner is the subset of the storage interface required for TTL cleanup.
+// A storage backend that supports TTL-based eviction implements this interface.
+type Cleaner interface {
+	ExpiredQueueIDs(ctx context.Context, before time.Time) ([]string, error)
+	DeleteQueue(ctx context.Context, id string) error
+}
+
+// Runner periodically asks a Cleaner to drop expired queues.
+type Runner struct {
+	Cleaner  Cleaner
+	Interval time.Duration
+	Logger   *slog.Logger
+	// Now returns the current time; tests inject a fake clock.
+	Now func() time.Time
+}
+
+// Run blocks until ctx is cancelled, calling Tick at every Interval.
+func (r *Runner) Run(ctx context.Context) {
+	if r.Interval <= 0 {
+		return
+	}
+	t := time.NewTicker(r.Interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			r.Tick(ctx)
+		}
+	}
+}
+
+// Tick performs one cleanup pass and returns the number of queues deleted.
+//
+// Errors from the Cleaner are logged but do not stop the runner; transient
+// failures (locked database, disk full) should resolve on the next tick.
+func (r *Runner) Tick(ctx context.Context) int {
+	now := time.Now().UTC()
+	if r.Now != nil {
+		now = r.Now()
+	}
+	ids, err := r.Cleaner.ExpiredQueueIDs(ctx, now)
+	if err != nil {
+		r.log(ctx, slog.LevelError, "list expired queues", "err", err.Error())
+		return 0
+	}
+	deleted := 0
+	for _, id := range ids {
+		if err := r.Cleaner.DeleteQueue(ctx, id); err != nil {
+			if errors.Is(err, queue.ErrQueueNotFound) {
+				continue
+			}
+			r.log(ctx, slog.LevelError, "delete expired queue", "err", err.Error())
+			continue
+		}
+		deleted++
+	}
+	if deleted > 0 {
+		r.log(ctx, slog.LevelInfo, "cleanup tick complete", "deleted", deleted)
+	}
+	return deleted
+}
+
+func (r *Runner) log(ctx context.Context, level slog.Level, msg string, attrs ...any) {
+	if r.Logger == nil {
+		return
+	}
+	r.Logger.LogAttrs(ctx, level, msg, sliceToAttrs(attrs)...)
+}
+
+// sliceToAttrs adapts a flat key-value slice to []slog.Attr for LogAttrs.
+func sliceToAttrs(kv []any) []slog.Attr {
+	if len(kv)%2 != 0 {
+		return nil
+	}
+	out := make([]slog.Attr, 0, len(kv)/2)
+	for i := 0; i < len(kv); i += 2 {
+		key, ok := kv[i].(string)
+		if !ok {
+			continue
+		}
+		out = append(out, slog.Any(key, kv[i+1]))
+	}
+	return out
+}

--- a/server/internal/storage/cleanup/cleanup_test.go
+++ b/server/internal/storage/cleanup/cleanup_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package cleanup_test
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/WissCore/moldchat/server/internal/queue"
+	"github.com/WissCore/moldchat/server/internal/storage/cleanup"
+	"github.com/WissCore/moldchat/server/internal/storage/sqlite"
+)
+
+type fakeCleaner struct {
+	expired    []string
+	deleted    []string
+	listErr    error
+	deleteErrs map[string]error
+}
+
+func (f *fakeCleaner) ExpiredQueueIDs(_ context.Context, _ time.Time) ([]string, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.expired, nil
+}
+
+func (f *fakeCleaner) DeleteQueue(_ context.Context, id string) error {
+	if err, ok := f.deleteErrs[id]; ok {
+		return err
+	}
+	f.deleted = append(f.deleted, id)
+	return nil
+}
+
+func TestTick_DeletesExpiredQueues(t *testing.T) {
+	t.Parallel()
+
+	c := &fakeCleaner{expired: []string{"q1", "q2", "q3"}}
+	r := &cleanup.Runner{Cleaner: c}
+	got := r.Tick(context.Background())
+
+	if got != 3 {
+		t.Errorf("deleted: got %d, want 3", got)
+	}
+	if len(c.deleted) != 3 {
+		t.Errorf("delete calls: got %d, want 3", len(c.deleted))
+	}
+}
+
+func TestTick_NothingToClean(t *testing.T) {
+	t.Parallel()
+
+	c := &fakeCleaner{expired: nil}
+	r := &cleanup.Runner{Cleaner: c}
+	if got := r.Tick(context.Background()); got != 0 {
+		t.Errorf("deleted: got %d, want 0", got)
+	}
+}
+
+func TestTick_SkipsRaceyAlreadyGone(t *testing.T) {
+	t.Parallel()
+
+	c := &fakeCleaner{
+		expired: []string{"q1", "q2"},
+		deleteErrs: map[string]error{
+			"q1": queue.ErrQueueNotFound,
+		},
+	}
+	r := &cleanup.Runner{Cleaner: c}
+	got := r.Tick(context.Background())
+
+	if got != 1 {
+		t.Errorf("deleted: got %d, want 1 (q2; q1 was already gone)", got)
+	}
+}
+
+func TestTick_ContinuesAfterDeleteError(t *testing.T) {
+	t.Parallel()
+
+	c := &fakeCleaner{
+		expired: []string{"q1", "q2"},
+		deleteErrs: map[string]error{
+			"q1": errors.New("disk full"),
+		},
+	}
+	r := &cleanup.Runner{Cleaner: c}
+	if got := r.Tick(context.Background()); got != 1 {
+		t.Errorf("deleted: got %d, want 1 (q2 succeeded; q1 errored)", got)
+	}
+}
+
+func TestTick_ListErrorReturnsZero(t *testing.T) {
+	t.Parallel()
+
+	c := &fakeCleaner{listErr: errors.New("db locked")}
+	r := &cleanup.Runner{Cleaner: c}
+	if got := r.Tick(context.Background()); got != 0 {
+		t.Errorf("deleted on list error: got %d, want 0", got)
+	}
+}
+
+// Integration test: run against a real SQLCipher store with a frozen clock.
+func TestTick_AgainstRealSQLiteStore(t *testing.T) {
+	t.Parallel()
+
+	var seed sqlite.MasterSeed
+	if _, err := rand.Read(seed[:]); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	dir := t.TempDir()
+	st, err := sqlite.New(seed, dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	ctx := context.Background()
+	owner := make([]byte, queue.OwnerKeyBytes)
+	q, err := st.CreateQueue(ctx, owner)
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	// "Now" is 48h in the future, so the queue (TTL 24h) is expired.
+	r := &cleanup.Runner{
+		Cleaner: st,
+		Now:     func() time.Time { return time.Now().Add(48 * time.Hour) },
+	}
+	if got := r.Tick(ctx); got != 1 {
+		t.Errorf("deleted: got %d, want 1", got)
+	}
+	if _, err := st.GetQueue(ctx, q.ID); !errors.Is(err, queue.ErrQueueNotFound) {
+		t.Errorf("queue still present after cleanup: %v", err)
+	}
+	// File on disk should be gone.
+	path := filepath.Join(dir, q.ID+".db")
+	if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("queue db file still exists after cleanup: %v", statErr)
+	}
+}

--- a/server/internal/storage/cleanup/cleanup_test.go
+++ b/server/internal/storage/cleanup/cleanup_test.go
@@ -123,8 +123,11 @@ func TestTick_AgainstRealSQLiteStore(t *testing.T) {
 	defer func() { _ = st.Close() }()
 
 	ctx := context.Background()
-	owner := make([]byte, queue.OwnerKeyBytes)
-	q, err := st.CreateQueue(ctx, owner)
+	keys := queue.OwnerKeys{
+		X25519Pub:  make([]byte, queue.X25519PubKeyBytes),
+		Ed25519Pub: make([]byte, queue.Ed25519PubKeyBytes),
+	}
+	q, err := st.CreateQueue(ctx, keys)
 	if err != nil {
 		t.Fatalf("CreateQueue: %v", err)
 	}

--- a/server/internal/storage/memory/memory.go
+++ b/server/internal/storage/memory/memory.go
@@ -33,9 +33,9 @@ func New() *Storage {
 	}
 }
 
-// CreateQueue registers a new queue owned by the given key.
-func (s *Storage) CreateQueue(_ context.Context, ownerKey []byte) (*queue.Queue, error) {
-	if err := queue.ValidateOwnerKey(ownerKey); err != nil {
+// CreateQueue registers a new queue owned by the given key pair.
+func (s *Storage) CreateQueue(_ context.Context, keys queue.OwnerKeys) (*queue.Queue, error) {
+	if err := queue.ValidateOwnerKeys(keys); err != nil {
 		return nil, err
 	}
 	id, err := queue.NewID()
@@ -44,11 +44,12 @@ func (s *Storage) CreateQueue(_ context.Context, ownerKey []byte) (*queue.Queue,
 	}
 	now := time.Now().UTC()
 	q := &queue.Queue{
-		ID:         id,
-		OwnerKey:   append([]byte(nil), ownerKey...),
-		CreatedAt:  now,
-		ExpiresAt:  now.Add(queue.DefaultTTL),
-		LastAccess: now,
+		ID:              id,
+		OwnerX25519Pub:  append([]byte(nil), keys.X25519Pub...),
+		OwnerEd25519Pub: append([]byte(nil), keys.Ed25519Pub...),
+		CreatedAt:       now,
+		ExpiresAt:       now.Add(queue.DefaultTTL),
+		LastAccess:      now,
 	}
 	s.mu.Lock()
 	s.queues[id] = q
@@ -150,7 +151,8 @@ func (s *Storage) DeleteMessage(_ context.Context, queueID, messageID string) er
 
 func cloneQueue(q *queue.Queue) *queue.Queue {
 	cp := *q
-	cp.OwnerKey = append([]byte(nil), q.OwnerKey...)
+	cp.OwnerX25519Pub = append([]byte(nil), q.OwnerX25519Pub...)
+	cp.OwnerEd25519Pub = append([]byte(nil), q.OwnerEd25519Pub...)
 	return &cp
 }
 

--- a/server/internal/storage/memory/memory_test.go
+++ b/server/internal/storage/memory/memory_test.go
@@ -14,12 +14,26 @@ import (
 	"github.com/WissCore/moldchat/server/internal/storage/memory"
 )
 
-func TestCreateQueue_RejectsInvalidKey(t *testing.T) {
+func validKeys() queue.OwnerKeys {
+	return queue.OwnerKeys{
+		X25519Pub:  make([]byte, queue.X25519PubKeyBytes),
+		Ed25519Pub: make([]byte, queue.Ed25519PubKeyBytes),
+	}
+}
+
+func TestCreateQueue_RejectsInvalidKeys(t *testing.T) {
 	t.Parallel()
 
 	s := memory.New()
-	if _, err := s.CreateQueue(context.Background(), make([]byte, 31)); !errors.Is(err, queue.ErrInvalidOwnerKey) {
-		t.Errorf("CreateQueue with 31-byte key: got %v, want ErrInvalidOwnerKey", err)
+
+	bad := queue.OwnerKeys{X25519Pub: make([]byte, 31), Ed25519Pub: make([]byte, 32)}
+	if _, err := s.CreateQueue(context.Background(), bad); !errors.Is(err, queue.ErrInvalidX25519Key) {
+		t.Errorf("31-byte X25519: got %v, want ErrInvalidX25519Key", err)
+	}
+
+	bad = queue.OwnerKeys{X25519Pub: make([]byte, 32), Ed25519Pub: make([]byte, 31)}
+	if _, err := s.CreateQueue(context.Background(), bad); !errors.Is(err, queue.ErrInvalidEd25519Key) {
+		t.Errorf("31-byte Ed25519: got %v, want ErrInvalidEd25519Key", err)
 	}
 }
 
@@ -28,7 +42,7 @@ func TestPutAndListMessages_RoundTrip(t *testing.T) {
 
 	s := memory.New()
 	ctx := context.Background()
-	q, err := s.CreateQueue(ctx, make([]byte, 32))
+	q, err := s.CreateQueue(ctx, validKeys())
 	if err != nil {
 		t.Fatalf("CreateQueue: %v", err)
 	}
@@ -56,7 +70,7 @@ func TestPutMessage_RejectsEmpty(t *testing.T) {
 
 	s := memory.New()
 	ctx := context.Background()
-	q, err := s.CreateQueue(ctx, make([]byte, 32))
+	q, err := s.CreateQueue(ctx, validKeys())
 	if err != nil {
 		t.Fatalf("CreateQueue: %v", err)
 	}
@@ -70,7 +84,7 @@ func TestPutMessage_RejectsTooLarge(t *testing.T) {
 
 	s := memory.New()
 	ctx := context.Background()
-	q, err := s.CreateQueue(ctx, make([]byte, 32))
+	q, err := s.CreateQueue(ctx, validKeys())
 	if err != nil {
 		t.Fatalf("CreateQueue: %v", err)
 	}
@@ -93,7 +107,7 @@ func TestListMessages_HasMore(t *testing.T) {
 
 	s := memory.New()
 	ctx := context.Background()
-	q, err := s.CreateQueue(ctx, make([]byte, 32))
+	q, err := s.CreateQueue(ctx, validKeys())
 	if err != nil {
 		t.Fatalf("CreateQueue: %v", err)
 	}
@@ -119,7 +133,7 @@ func TestDeleteMessage_RoundTrip(t *testing.T) {
 
 	s := memory.New()
 	ctx := context.Background()
-	q, err := s.CreateQueue(ctx, make([]byte, 32))
+	q, err := s.CreateQueue(ctx, validKeys())
 	if err != nil {
 		t.Fatalf("CreateQueue: %v", err)
 	}

--- a/server/internal/storage/sqlite/keys.go
+++ b/server/internal/storage/sqlite/keys.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package sqlite implements storage.Storage on top of a SQLCipher-encrypted
+// SQLite database. Per-queue databases live in their own files; their
+// encryption keys are derived from a single master seed via HKDF.
+package sqlite
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+// MasterSeedBytes is the length of the master seed in bytes.
+const MasterSeedBytes = 32
+
+// MasterSeed is a high-entropy 32-byte secret used to derive per-database
+// SQLCipher keys. It is loaded once at startup; production deployments should
+// fetch it from an HSM or KMS rather than from an environment variable.
+type MasterSeed [MasterSeedBytes]byte
+
+// envVarMasterSeed is the environment variable that supplies the seed.
+const envVarMasterSeed = "MOLDD_MASTER_SEED"
+
+// Sentinel errors related to seed loading.
+var (
+	ErrMasterSeedMissing = errors.New("master seed missing: set " + envVarMasterSeed)
+	ErrMasterSeedInvalid = fmt.Errorf("master seed must be base64-encoded %d bytes", MasterSeedBytes)
+)
+
+// LoadMasterSeed reads the seed from the environment variable.
+//
+// The value must be a base64 encoding (standard, with or without padding) of
+// exactly MasterSeedBytes bytes.
+func LoadMasterSeed() (MasterSeed, error) {
+	raw := os.Getenv(envVarMasterSeed)
+	if raw == "" {
+		return MasterSeed{}, ErrMasterSeedMissing
+	}
+	return parseSeed(raw)
+}
+
+func parseSeed(raw string) (MasterSeed, error) {
+	for _, dec := range []*base64.Encoding{base64.StdEncoding, base64.RawStdEncoding} {
+		buf, err := dec.DecodeString(raw)
+		if err == nil && len(buf) == MasterSeedBytes {
+			var seed MasterSeed
+			copy(seed[:], buf)
+			return seed, nil
+		}
+	}
+	return MasterSeed{}, ErrMasterSeedInvalid
+}
+
+// HKDF info strings. Versioning the namespace allows a future migration to
+// rotate keys without losing access to data encrypted under the old scheme.
+const (
+	infoMasterDB = "moldd-master-key-v1"
+	infoQueueDB  = "moldd-queue-key-v1|"
+)
+
+// MasterKey returns the SQLCipher hex key (without 'x' wrapper) for the
+// master metadata database.
+func (m MasterSeed) MasterKey() string {
+	return deriveKey(m[:], []byte(infoMasterDB))
+}
+
+// DeriveQueueKey returns the SQLCipher hex key (without 'x' wrapper) for the
+// per-queue database identified by queueID.
+func (m MasterSeed) DeriveQueueKey(queueID string) string {
+	return deriveKey(m[:], append([]byte(infoQueueDB), []byte(queueID)...))
+}
+
+// deriveKey runs HKDF-Expand with SHA-256 over the IKM and returns 32 bytes
+// hex-encoded uppercase, ready to be embedded in a SQLCipher PRAGMA key.
+func deriveKey(ikm, info []byte) string {
+	r := hkdf.New(sha256.New, ikm, nil, info)
+	out := make([]byte, MasterSeedBytes)
+	if _, err := io.ReadFull(r, out); err != nil {
+		// HKDF.Read on SHA-256 output cannot fail under reasonable constraints
+		// (we request a single-block expansion); treat any I/O error as fatal.
+		panic(fmt.Errorf("hkdf read: %w", err))
+	}
+	return hex.EncodeToString(out)
+}

--- a/server/internal/storage/sqlite/keys_test.go
+++ b/server/internal/storage/sqlite/keys_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sqlite_test
+
+import (
+	"encoding/base64"
+	"errors"
+	"testing"
+
+	"github.com/WissCore/moldchat/server/internal/storage/sqlite"
+)
+
+func TestDeriveQueueKey_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	var seed sqlite.MasterSeed
+	for i := range seed {
+		seed[i] = byte(i)
+	}
+	a := seed.DeriveQueueKey("queue-1")
+	b := seed.DeriveQueueKey("queue-1")
+	if a != b {
+		t.Errorf("derive is not deterministic: %s != %s", a, b)
+	}
+}
+
+func TestDeriveQueueKey_DistinctPerQueue(t *testing.T) {
+	t.Parallel()
+
+	var seed sqlite.MasterSeed
+	for i := range seed {
+		seed[i] = byte(i)
+	}
+	a := seed.DeriveQueueKey("queue-1")
+	b := seed.DeriveQueueKey("queue-2")
+	if a == b {
+		t.Errorf("two queues produced the same key: %s", a)
+	}
+}
+
+func TestDeriveQueueKey_IsolatedFromMaster(t *testing.T) {
+	t.Parallel()
+
+	var seed sqlite.MasterSeed
+	master := seed.MasterKey()
+	queue := seed.DeriveQueueKey("any-id")
+	if master == queue {
+		t.Errorf("master key collides with queue key: %s", master)
+	}
+}
+
+func TestDeriveKey_Length(t *testing.T) {
+	t.Parallel()
+
+	var seed sqlite.MasterSeed
+	got := seed.DeriveQueueKey("anything")
+	if len(got) != 64 {
+		t.Errorf("hex key length: got %d, want 64", len(got))
+	}
+}
+
+func TestLoadMasterSeed_MissingEnv(t *testing.T) {
+	t.Setenv("MOLDD_MASTER_SEED", "")
+
+	_, err := sqlite.LoadMasterSeed()
+	if !errors.Is(err, sqlite.ErrMasterSeedMissing) {
+		t.Errorf("got %v, want ErrMasterSeedMissing", err)
+	}
+}
+
+func TestLoadMasterSeed_InvalidLength(t *testing.T) {
+	t.Setenv("MOLDD_MASTER_SEED", base64.StdEncoding.EncodeToString([]byte("too-short")))
+
+	_, err := sqlite.LoadMasterSeed()
+	if err == nil {
+		t.Fatalf("expected error for short seed, got nil")
+	}
+	if errors.Is(err, sqlite.ErrMasterSeedMissing) {
+		t.Errorf("classified as Missing instead of Invalid")
+	}
+}
+
+func TestLoadMasterSeed_Valid(t *testing.T) {
+	raw := make([]byte, sqlite.MasterSeedBytes)
+	for i := range raw {
+		raw[i] = byte(i + 1)
+	}
+	t.Setenv("MOLDD_MASTER_SEED", base64.StdEncoding.EncodeToString(raw))
+
+	seed, err := sqlite.LoadMasterSeed()
+	if err != nil {
+		t.Fatalf("LoadMasterSeed: %v", err)
+	}
+	if seed[0] != 1 || seed[31] != 32 {
+		t.Errorf("seed mismatch: first=%d last=%d", seed[0], seed[31])
+	}
+}

--- a/server/internal/storage/sqlite/store.go
+++ b/server/internal/storage/sqlite/store.go
@@ -1,0 +1,368 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/WissCore/moldchat/server/internal/queue"
+
+	// Registers the "sqlite3" driver with SQLCipher 4.x support.
+	_ "github.com/mutecomm/go-sqlcipher/v4"
+)
+
+const (
+	driverName          = "sqlite3"
+	masterFilename      = "master.db"
+	queueFilenameSuffix = ".db"
+	cipherPageSize      = 4096
+	dataDirPerm         = 0o700
+)
+
+// Store is a SQLCipher-backed implementation of storage.Storage.
+//
+// One master database holds queue metadata; each queue's messages live in
+// their own encrypted file. Database keys are derived from a single master
+// seed via HKDF, so seizing the storage directory without the seed yields
+// only opaque ciphertext.
+type Store struct {
+	seed     MasterSeed
+	dataDir  string
+	masterDB *sql.DB
+
+	mu sync.Mutex
+}
+
+// New opens (or creates) the master database and initialises its schema.
+// dataDir is created with 0700 permissions if it does not exist.
+func New(seed MasterSeed, dataDir string) (*Store, error) {
+	abs, err := filepath.Abs(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve dataDir: %w", err)
+	}
+	if mkdirErr := os.MkdirAll(abs, dataDirPerm); mkdirErr != nil {
+		return nil, fmt.Errorf("create dataDir: %w", mkdirErr)
+	}
+	masterDB, err := openEncryptedDB(filepath.Join(abs, masterFilename), seed.MasterKey())
+	if err != nil {
+		return nil, fmt.Errorf("open master.db: %w", err)
+	}
+	if _, schemaErr := masterDB.Exec(masterSchema); schemaErr != nil {
+		_ = masterDB.Close()
+		return nil, fmt.Errorf("init master schema: %w", schemaErr)
+	}
+	return &Store{seed: seed, dataDir: abs, masterDB: masterDB}, nil
+}
+
+// Close releases resources held by the store.
+func (s *Store) Close() error { return s.masterDB.Close() }
+
+const masterSchema = `
+CREATE TABLE IF NOT EXISTS queues (
+	id           TEXT    PRIMARY KEY,
+	owner_key    BLOB    NOT NULL,
+	created_at   INTEGER NOT NULL,
+	expires_at   INTEGER NOT NULL,
+	last_access  INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_queues_expires_at ON queues(expires_at);
+`
+
+const queueSchema = `
+CREATE TABLE IF NOT EXISTS messages (
+	id           TEXT    PRIMARY KEY,
+	blob         BLOB    NOT NULL,
+	received_at  INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_messages_received_at ON messages(received_at);
+`
+
+// openEncryptedDB opens a SQLCipher database at path with the given hex key.
+// The connection pool is capped at 1 to match SQLite's single-writer model.
+func openEncryptedDB(path, hexKey string) (*sql.DB, error) {
+	dsn := fmt.Sprintf("file:%s?_pragma_key=x'%s'&_pragma_cipher_page_size=%d",
+		path, hexKey, cipherPageSize)
+	db, err := sql.Open(driverName, dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	if pingErr := db.Ping(); pingErr != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("ping db: %w", pingErr)
+	}
+	return db, nil
+}
+
+func (s *Store) queuePath(queueID string) string {
+	return filepath.Join(s.dataDir, queueID+queueFilenameSuffix)
+}
+
+// openQueue opens (and initialises if needed) the per-queue database.
+// The returned handle must be closed by the caller.
+func (s *Store) openQueue(queueID string) (*sql.DB, error) {
+	db, err := openEncryptedDB(s.queuePath(queueID), s.seed.DeriveQueueKey(queueID))
+	if err != nil {
+		return nil, err
+	}
+	if _, schemaErr := db.Exec(queueSchema); schemaErr != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("init queue schema: %w", schemaErr)
+	}
+	return db, nil
+}
+
+// CreateQueue inserts a new queue row and creates its per-queue database file.
+func (s *Store) CreateQueue(ctx context.Context, ownerKey []byte) (*queue.Queue, error) {
+	if err := queue.ValidateOwnerKey(ownerKey); err != nil {
+		return nil, err
+	}
+	id, err := queue.NewID()
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	expires := now.Add(queue.DefaultTTL)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, execErr := s.masterDB.ExecContext(ctx,
+		`INSERT INTO queues(id, owner_key, created_at, expires_at, last_access) VALUES (?, ?, ?, ?, ?)`,
+		id, ownerKey, now.UnixNano(), expires.UnixNano(), now.UnixNano(),
+	); execErr != nil {
+		return nil, fmt.Errorf("insert queue: %w", execErr)
+	}
+
+	qdb, err := s.openQueue(id)
+	if err != nil {
+		// Roll back the master row so we do not leak a metadata entry without a file.
+		_, _ = s.masterDB.ExecContext(ctx, `DELETE FROM queues WHERE id = ?`, id)
+		return nil, fmt.Errorf("init queue db: %w", err)
+	}
+	_ = qdb.Close()
+
+	return &queue.Queue{
+		ID:         id,
+		OwnerKey:   append([]byte(nil), ownerKey...),
+		CreatedAt:  now,
+		ExpiresAt:  expires,
+		LastAccess: now,
+	}, nil
+}
+
+// GetQueue returns queue metadata or queue.ErrQueueNotFound.
+func (s *Store) GetQueue(ctx context.Context, id string) (*queue.Queue, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.getQueueLocked(ctx, id)
+}
+
+func (s *Store) getQueueLocked(ctx context.Context, id string) (*queue.Queue, error) {
+	var (
+		q                                queue.Queue
+		createdNs, expiresNs, lastAccess int64
+	)
+	row := s.masterDB.QueryRowContext(ctx,
+		`SELECT id, owner_key, created_at, expires_at, last_access FROM queues WHERE id = ?`, id,
+	)
+	if err := row.Scan(&q.ID, &q.OwnerKey, &createdNs, &expiresNs, &lastAccess); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, queue.ErrQueueNotFound
+		}
+		return nil, err
+	}
+	q.CreatedAt = time.Unix(0, createdNs).UTC()
+	q.ExpiresAt = time.Unix(0, expiresNs).UTC()
+	q.LastAccess = time.Unix(0, lastAccess).UTC()
+	return &q, nil
+}
+
+// PutMessage appends an opaque blob to the queue.
+func (s *Store) PutMessage(ctx context.Context, queueID string, blob []byte) (*queue.Message, error) {
+	switch {
+	case len(blob) == 0:
+		return nil, queue.ErrEmptyBlob
+	case len(blob) > queue.MaxBlobSize:
+		return nil, queue.ErrBlobTooLarge
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, err := s.getQueueLocked(ctx, queueID); err != nil {
+		return nil, err
+	}
+
+	qdb, err := s.openQueue(queueID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = qdb.Close() }()
+
+	msgID, err := queue.NewMessageID()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+
+	if _, execErr := qdb.ExecContext(ctx,
+		`INSERT INTO messages(id, blob, received_at) VALUES (?, ?, ?)`,
+		msgID, blob, now.UnixNano(),
+	); execErr != nil {
+		return nil, fmt.Errorf("insert message: %w", execErr)
+	}
+
+	if err := s.touchQueue(ctx, queueID, now); err != nil {
+		return nil, err
+	}
+
+	return &queue.Message{
+		ID:         msgID,
+		QueueID:    queueID,
+		Blob:       append([]byte(nil), blob...),
+		ReceivedAt: now,
+	}, nil
+}
+
+// ListMessages returns up to limit messages in arrival order plus a hasMore flag.
+func (s *Store) ListMessages(ctx context.Context, queueID string, limit int) ([]*queue.Message, bool, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 100
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, err := s.getQueueLocked(ctx, queueID); err != nil {
+		return nil, false, err
+	}
+
+	qdb, err := s.openQueue(queueID)
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { _ = qdb.Close() }()
+
+	rows, err := qdb.QueryContext(ctx,
+		`SELECT id, blob, received_at FROM messages ORDER BY received_at ASC LIMIT ?`, limit+1,
+	)
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var msgs []*queue.Message
+	for rows.Next() {
+		var (
+			m          queue.Message
+			receivedNs int64
+		)
+		if scanErr := rows.Scan(&m.ID, &m.Blob, &receivedNs); scanErr != nil {
+			return nil, false, scanErr
+		}
+		m.QueueID = queueID
+		m.ReceivedAt = time.Unix(0, receivedNs).UTC()
+		msgs = append(msgs, &m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
+	}
+
+	hasMore := len(msgs) > limit
+	if hasMore {
+		msgs = msgs[:limit]
+	}
+	if err := s.touchQueue(ctx, queueID, time.Now().UTC()); err != nil {
+		return nil, false, err
+	}
+	return msgs, hasMore, nil
+}
+
+// DeleteMessage removes a single message from the queue.
+func (s *Store) DeleteMessage(ctx context.Context, queueID, messageID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, err := s.getQueueLocked(ctx, queueID); err != nil {
+		return err
+	}
+
+	qdb, err := s.openQueue(queueID)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = qdb.Close() }()
+
+	res, err := qdb.ExecContext(ctx, `DELETE FROM messages WHERE id = ?`, messageID)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return queue.ErrMessageNotFound
+	}
+	return s.touchQueue(ctx, queueID, time.Now().UTC())
+}
+
+func (s *Store) touchQueue(ctx context.Context, queueID string, t time.Time) error {
+	_, err := s.masterDB.ExecContext(ctx,
+		`UPDATE queues SET last_access = ? WHERE id = ?`, t.UnixNano(), queueID)
+	return err
+}
+
+// ExpiredQueueIDs returns queue identifiers whose expires_at is before t.
+func (s *Store) ExpiredQueueIDs(ctx context.Context, t time.Time) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rows, err := s.masterDB.QueryContext(ctx,
+		`SELECT id FROM queues WHERE expires_at < ?`, t.UnixNano())
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if scanErr := rows.Scan(&id); scanErr != nil {
+			return nil, scanErr
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// DeleteQueue removes a queue's metadata row and its database file.
+// Used by the TTL cleanup goroutine.
+func (s *Store) DeleteQueue(ctx context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	res, err := s.masterDB.ExecContext(ctx, `DELETE FROM queues WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		return queue.ErrQueueNotFound
+	}
+	if removeErr := os.Remove(s.queuePath(id)); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+		return fmt.Errorf("remove queue db file: %w", removeErr)
+	}
+	return nil
+}

--- a/server/internal/storage/sqlite/store.go
+++ b/server/internal/storage/sqlite/store.go
@@ -68,20 +68,23 @@ func (s *Store) Close() error { return s.masterDB.Close() }
 
 const masterSchema = `
 CREATE TABLE IF NOT EXISTS queues (
-	id           TEXT    PRIMARY KEY,
-	owner_key    BLOB    NOT NULL,
-	created_at   INTEGER NOT NULL,
-	expires_at   INTEGER NOT NULL,
-	last_access  INTEGER NOT NULL
+	id                 TEXT    NOT NULL,
+	owner_x25519_pub   BLOB    NOT NULL,
+	owner_ed25519_pub  BLOB    NOT NULL,
+	created_at         INTEGER NOT NULL,
+	expires_at         INTEGER NOT NULL,
+	last_access        INTEGER NOT NULL,
+	PRIMARY KEY (id)
 );
 CREATE INDEX IF NOT EXISTS idx_queues_expires_at ON queues(expires_at);
 `
 
 const queueSchema = `
 CREATE TABLE IF NOT EXISTS messages (
-	id           TEXT    PRIMARY KEY,
+	id           TEXT    NOT NULL,
 	blob         BLOB    NOT NULL,
-	received_at  INTEGER NOT NULL
+	received_at  INTEGER NOT NULL,
+	PRIMARY KEY (id)
 );
 CREATE INDEX IF NOT EXISTS idx_messages_received_at ON messages(received_at);
 `
@@ -122,8 +125,8 @@ func (s *Store) openQueue(queueID string) (*sql.DB, error) {
 }
 
 // CreateQueue inserts a new queue row and creates its per-queue database file.
-func (s *Store) CreateQueue(ctx context.Context, ownerKey []byte) (*queue.Queue, error) {
-	if err := queue.ValidateOwnerKey(ownerKey); err != nil {
+func (s *Store) CreateQueue(ctx context.Context, keys queue.OwnerKeys) (*queue.Queue, error) {
+	if err := queue.ValidateOwnerKeys(keys); err != nil {
 		return nil, err
 	}
 	id, err := queue.NewID()
@@ -138,8 +141,8 @@ func (s *Store) CreateQueue(ctx context.Context, ownerKey []byte) (*queue.Queue,
 	defer s.mu.Unlock()
 
 	if _, execErr := s.masterDB.ExecContext(ctx,
-		`INSERT INTO queues(id, owner_key, created_at, expires_at, last_access) VALUES (?, ?, ?, ?, ?)`,
-		id, ownerKey, now.UnixNano(), expires.UnixNano(), now.UnixNano(),
+		`INSERT INTO queues(id, owner_x25519_pub, owner_ed25519_pub, created_at, expires_at, last_access) VALUES (?, ?, ?, ?, ?, ?)`,
+		id, keys.X25519Pub, keys.Ed25519Pub, now.UnixNano(), expires.UnixNano(), now.UnixNano(),
 	); execErr != nil {
 		return nil, fmt.Errorf("insert queue: %w", execErr)
 	}
@@ -153,11 +156,12 @@ func (s *Store) CreateQueue(ctx context.Context, ownerKey []byte) (*queue.Queue,
 	_ = qdb.Close()
 
 	return &queue.Queue{
-		ID:         id,
-		OwnerKey:   append([]byte(nil), ownerKey...),
-		CreatedAt:  now,
-		ExpiresAt:  expires,
-		LastAccess: now,
+		ID:              id,
+		OwnerX25519Pub:  append([]byte(nil), keys.X25519Pub...),
+		OwnerEd25519Pub: append([]byte(nil), keys.Ed25519Pub...),
+		CreatedAt:       now,
+		ExpiresAt:       expires,
+		LastAccess:      now,
 	}, nil
 }
 
@@ -174,9 +178,9 @@ func (s *Store) getQueueLocked(ctx context.Context, id string) (*queue.Queue, er
 		createdNs, expiresNs, lastAccess int64
 	)
 	row := s.masterDB.QueryRowContext(ctx,
-		`SELECT id, owner_key, created_at, expires_at, last_access FROM queues WHERE id = ?`, id,
+		`SELECT id, owner_x25519_pub, owner_ed25519_pub, created_at, expires_at, last_access FROM queues WHERE id = ?`, id,
 	)
-	if err := row.Scan(&q.ID, &q.OwnerKey, &createdNs, &expiresNs, &lastAccess); err != nil {
+	if err := row.Scan(&q.ID, &q.OwnerX25519Pub, &q.OwnerEd25519Pub, &createdNs, &expiresNs, &lastAccess); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, queue.ErrQueueNotFound
 		}

--- a/server/internal/storage/sqlite/store_test.go
+++ b/server/internal/storage/sqlite/store_test.go
@@ -37,13 +37,19 @@ func newTestStore(t *testing.T) (*sqlite.Store, string) {
 	return st, dir
 }
 
-func ownerKey(t *testing.T) []byte {
+func ownerKeys(t *testing.T) queue.OwnerKeys {
 	t.Helper()
-	k := make([]byte, queue.OwnerKeyBytes)
-	if _, err := rand.Read(k); err != nil {
-		t.Fatalf("rand: %v", err)
+	keys := queue.OwnerKeys{
+		X25519Pub:  make([]byte, queue.X25519PubKeyBytes),
+		Ed25519Pub: make([]byte, queue.Ed25519PubKeyBytes),
 	}
-	return k
+	if _, err := rand.Read(keys.X25519Pub); err != nil {
+		t.Fatalf("rand x25519: %v", err)
+	}
+	if _, err := rand.Read(keys.Ed25519Pub); err != nil {
+		t.Fatalf("rand ed25519: %v", err)
+	}
+	return keys
 }
 
 func TestNew_CreatesDataDir(t *testing.T) {
@@ -71,7 +77,7 @@ func TestCreateAndPutAndList_RoundTrip(t *testing.T) {
 	st, _ := newTestStore(t)
 	ctx := context.Background()
 
-	q, err := st.CreateQueue(ctx, ownerKey(t))
+	q, err := st.CreateQueue(ctx, ownerKeys(t))
 	if err != nil {
 		t.Fatalf("CreateQueue: %v", err)
 	}
@@ -108,7 +114,7 @@ func TestDurability_AcrossRestart(t *testing.T) {
 		t.Fatalf("first New: %v", err)
 	}
 	ctx := context.Background()
-	q, err := first.CreateQueue(ctx, ownerKey(t))
+	q, err := first.CreateQueue(ctx, ownerKeys(t))
 	if err != nil {
 		t.Fatalf("CreateQueue: %v", err)
 	}
@@ -148,7 +154,7 @@ func TestEncryptionAtRest_DBFileIsOpaque(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if _, createErr := st.CreateQueue(context.Background(), ownerKey(t)); createErr != nil {
+	if _, createErr := st.CreateQueue(context.Background(), ownerKeys(t)); createErr != nil {
 		t.Fatalf("CreateQueue: %v", createErr)
 	}
 	if closeErr := st.Close(); closeErr != nil {
@@ -181,7 +187,7 @@ func TestPutMessage_RejectsTooLargeAndEmpty(t *testing.T) {
 	t.Parallel()
 	st, _ := newTestStore(t)
 	ctx := context.Background()
-	q, err := st.CreateQueue(ctx, ownerKey(t))
+	q, err := st.CreateQueue(ctx, ownerKeys(t))
 	if err != nil {
 		t.Fatalf("CreateQueue: %v", err)
 	}
@@ -198,7 +204,7 @@ func TestDeleteMessage_RoundTrip(t *testing.T) {
 	st, _ := newTestStore(t)
 	ctx := context.Background()
 
-	q, err := st.CreateQueue(ctx, ownerKey(t))
+	q, err := st.CreateQueue(ctx, ownerKeys(t))
 	if err != nil {
 		t.Fatalf("CreateQueue: %v", err)
 	}
@@ -226,7 +232,7 @@ func TestExpiredAndDeleteQueue(t *testing.T) {
 	st, dir := newTestStore(t)
 	ctx := context.Background()
 
-	q, err := st.CreateQueue(ctx, ownerKey(t))
+	q, err := st.CreateQueue(ctx, ownerKeys(t))
 	if err != nil {
 		t.Fatalf("CreateQueue: %v", err)
 	}

--- a/server/internal/storage/sqlite/store_test.go
+++ b/server/internal/storage/sqlite/store_test.go
@@ -1,0 +1,250 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sqlite_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/WissCore/moldchat/server/internal/queue"
+	"github.com/WissCore/moldchat/server/internal/storage/sqlite"
+
+	_ "github.com/mutecomm/go-sqlcipher/v4"
+)
+
+func newTestStore(t *testing.T) (*sqlite.Store, string) {
+	t.Helper()
+
+	var seed sqlite.MasterSeed
+	if _, err := rand.Read(seed[:]); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	dir := t.TempDir()
+	st, err := sqlite.New(seed, dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st, dir
+}
+
+func ownerKey(t *testing.T) []byte {
+	t.Helper()
+	k := make([]byte, queue.OwnerKeyBytes)
+	if _, err := rand.Read(k); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	return k
+}
+
+func TestNew_CreatesDataDir(t *testing.T) {
+	t.Parallel()
+
+	var seed sqlite.MasterSeed
+	dir := filepath.Join(t.TempDir(), "nested", "dir")
+	st, err := sqlite.New(seed, dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Errorf("dir permissions should be 0700, got %o", info.Mode().Perm())
+	}
+}
+
+func TestCreateAndPutAndList_RoundTrip(t *testing.T) {
+	t.Parallel()
+	st, _ := newTestStore(t)
+	ctx := context.Background()
+
+	q, err := st.CreateQueue(ctx, ownerKey(t))
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+	want := []byte("opaque-blob")
+	if _, putErr := st.PutMessage(ctx, q.ID, want); putErr != nil {
+		t.Fatalf("PutMessage: %v", putErr)
+	}
+	msgs, hasMore, err := st.ListMessages(ctx, q.ID, 10)
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+	if hasMore {
+		t.Errorf("hasMore: got true, want false")
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("len(msgs): got %d, want 1", len(msgs))
+	}
+	if !bytes.Equal(msgs[0].Blob, want) {
+		t.Errorf("blob round-trip: got %q, want %q", msgs[0].Blob, want)
+	}
+}
+
+func TestDurability_AcrossRestart(t *testing.T) {
+	t.Parallel()
+
+	var seed sqlite.MasterSeed
+	if _, err := rand.Read(seed[:]); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	dir := t.TempDir()
+
+	first, err := sqlite.New(seed, dir)
+	if err != nil {
+		t.Fatalf("first New: %v", err)
+	}
+	ctx := context.Background()
+	q, err := first.CreateQueue(ctx, ownerKey(t))
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+	want := []byte("persisted")
+	if _, putErr := first.PutMessage(ctx, q.ID, want); putErr != nil {
+		t.Fatalf("PutMessage: %v", putErr)
+	}
+	if closeErr := first.Close(); closeErr != nil {
+		t.Fatalf("close first: %v", closeErr)
+	}
+
+	second, err := sqlite.New(seed, dir)
+	if err != nil {
+		t.Fatalf("second New: %v", err)
+	}
+	defer func() { _ = second.Close() }()
+
+	msgs, _, err := second.ListMessages(ctx, q.ID, 10)
+	if err != nil {
+		t.Fatalf("ListMessages after restart: %v", err)
+	}
+	if len(msgs) != 1 || !bytes.Equal(msgs[0].Blob, want) {
+		t.Errorf("messages did not survive restart: %+v", msgs)
+	}
+}
+
+func TestEncryptionAtRest_DBFileIsOpaque(t *testing.T) {
+	t.Parallel()
+
+	var seed sqlite.MasterSeed
+	if _, err := rand.Read(seed[:]); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	dir := t.TempDir()
+
+	st, err := sqlite.New(seed, dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, createErr := st.CreateQueue(context.Background(), ownerKey(t)); createErr != nil {
+		t.Fatalf("CreateQueue: %v", createErr)
+	}
+	if closeErr := st.Close(); closeErr != nil {
+		t.Fatalf("close: %v", closeErr)
+	}
+
+	// The SQLite driver must refuse to open the file without the cipher key.
+	// This is the operational guarantee we care about: even with disk access,
+	// no process can read the database without MOLDD_MASTER_SEED.
+	db, err := sql.Open("sqlite3", "file:"+filepath.Join(dir, "master.db"))
+	if err != nil {
+		t.Fatalf("open without key: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if pingErr := db.Ping(); pingErr == nil {
+		t.Errorf("ping without key succeeded; the file is not encrypted")
+	}
+}
+
+func TestPutMessage_QueueNotFound(t *testing.T) {
+	t.Parallel()
+	st, _ := newTestStore(t)
+
+	if _, err := st.PutMessage(context.Background(), "missing-queue-id", []byte("x")); !errors.Is(err, queue.ErrQueueNotFound) {
+		t.Errorf("got %v, want ErrQueueNotFound", err)
+	}
+}
+
+func TestPutMessage_RejectsTooLargeAndEmpty(t *testing.T) {
+	t.Parallel()
+	st, _ := newTestStore(t)
+	ctx := context.Background()
+	q, err := st.CreateQueue(ctx, ownerKey(t))
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+	if _, err := st.PutMessage(ctx, q.ID, nil); !errors.Is(err, queue.ErrEmptyBlob) {
+		t.Errorf("empty: got %v, want ErrEmptyBlob", err)
+	}
+	if _, err := st.PutMessage(ctx, q.ID, make([]byte, queue.MaxBlobSize+1)); !errors.Is(err, queue.ErrBlobTooLarge) {
+		t.Errorf("oversize: got %v, want ErrBlobTooLarge", err)
+	}
+}
+
+func TestDeleteMessage_RoundTrip(t *testing.T) {
+	t.Parallel()
+	st, _ := newTestStore(t)
+	ctx := context.Background()
+
+	q, err := st.CreateQueue(ctx, ownerKey(t))
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+	m, err := st.PutMessage(ctx, q.ID, []byte("payload"))
+	if err != nil {
+		t.Fatalf("PutMessage: %v", err)
+	}
+	if delErr := st.DeleteMessage(ctx, q.ID, m.ID); delErr != nil {
+		t.Fatalf("DeleteMessage: %v", delErr)
+	}
+	msgs, _, err := st.ListMessages(ctx, q.ID, 10)
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("after delete: got %d msgs, want 0", len(msgs))
+	}
+	if err := st.DeleteMessage(ctx, q.ID, m.ID); !errors.Is(err, queue.ErrMessageNotFound) {
+		t.Errorf("second delete: got %v, want ErrMessageNotFound", err)
+	}
+}
+
+func TestExpiredAndDeleteQueue(t *testing.T) {
+	t.Parallel()
+	st, dir := newTestStore(t)
+	ctx := context.Background()
+
+	q, err := st.CreateQueue(ctx, ownerKey(t))
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+	// Far future cutoff: the queue is treated as expired.
+	ids, err := st.ExpiredQueueIDs(ctx, time.Now().Add(48*time.Hour))
+	if err != nil {
+		t.Fatalf("ExpiredQueueIDs: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != q.ID {
+		t.Fatalf("expected one expired id, got %v", ids)
+	}
+	if err := st.DeleteQueue(ctx, q.ID); err != nil {
+		t.Fatalf("DeleteQueue: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, q.ID+".db")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("queue file still exists: %v", err)
+	}
+	if _, err := st.GetQueue(ctx, q.ID); !errors.Is(err, queue.ErrQueueNotFound) {
+		t.Errorf("queue still in master: %v", err)
+	}
+}

--- a/server/internal/storage/storage.go
+++ b/server/internal/storage/storage.go
@@ -19,7 +19,7 @@ import (
 //
 // All methods are expected to be safe for concurrent use.
 type Storage interface {
-	CreateQueue(ctx context.Context, ownerKey []byte) (*queue.Queue, error)
+	CreateQueue(ctx context.Context, keys queue.OwnerKeys) (*queue.Queue, error)
 	GetQueue(ctx context.Context, id string) (*queue.Queue, error)
 	PutMessage(ctx context.Context, queueID string, blob []byte) (*queue.Message, error)
 	ListMessages(ctx context.Context, queueID string, limit int) (msgs []*queue.Message, hasMore bool, err error)


### PR DESCRIPTION
Encrypted SQLite backend: one queue maps to one .db file, keys are derived from a master seed via HKDF, and expired queues are evicted by a background cleanup runner. The backend is selected via the MOLDD_STORAGE env var ("memory" by default; "sqlite" for persistent storage requires MOLDD_MASTER_SEED — 32 bytes base64 — and MOLDD_DATA_DIR).

Replaces the placeholder X-Owner-Pubkey check with a full challenge-response. The client fetches a nonce from GET /v1/queues/{id}/auth-challenge (32 bytes, TTL 30s) and signs "moldd-v1-auth" || nonce || queue_id || method || path with its Ed25519 private key. The server constant-time-compares the pubkey against the queue's registered key, verifies the signature, and burns the nonce — replay is not possible. The owner key migrates to a pair {X25519Pub, Ed25519Pub}.

**Hardening:** a cap on outstanding nonces with 503 on saturation, Mount panics on uninitialised dependencies, atomic AuthFailureCount for future counter-pipeline integration.