### PR TITLE
feat(server): security hardening, crypto-shred, and expanded test coverage

### DIFF
--- a/docs/runbook/storage-operations.md
+++ b/docs/runbook/storage-operations.md
@@ -1,0 +1,108 @@
+# Storage operations runbook
+
+Operational guidance for deployments using the SQLCipher storage backend
+(`MOLDD_STORAGE=sqlite`). The code itself implements every guarantee
+that can be enforced from inside the process; the items below are
+host-level controls that the operator must apply to preserve those
+guarantees end to end.
+
+## Filesystem mount options
+
+Mount the directory pointed to by `MOLDD_DATA_DIR` with `noatime` (and,
+where supported, `nodiratime`):
+
+```fstab
+/dev/mapper/moldd-data  /var/lib/moldd  ext4  defaults,noatime,nodiratime  0 2
+```
+
+Without `noatime` the kernel updates an access timestamp every time the
+server reads a queue file. Anyone with read-only filesystem access (a
+backup tool, a forensic image, an unprivileged sidecar) can correlate
+those timestamps with traffic patterns — defeating the metadata-privacy
+half of the encryption-at-rest design.
+
+## Backup pipelines
+
+Both the master database (`master.db`) and its WAL files
+(`master.db-wal`, `master.db-shm`) must be captured atomically. The
+server periodically calls `PRAGMA wal_checkpoint(FULL)` after queue
+deletions so that crypto-shredded salts do not survive in the WAL, but
+between checkpoints the WAL holds recently-committed pages.
+
+Acceptable strategies:
+
+- File-system snapshot (LVM, ZFS, btrfs): captures all three files at
+  the same instant. Preferred.
+- `sqlite3 .backup` against a live `master.db`: SQLite handles the
+  consistency for you.
+- `cp master.db master.db-wal master.db-shm` while the server is
+  running: only safe if the filesystem provides ordered writes and the
+  caller copies all three files; otherwise the snapshot may be
+  inconsistent.
+
+Do **not** copy only `master.db`. A point-in-time `master.db` without
+its matching WAL is a stale snapshot whose semantics depend on whether
+the most recent checkpoint had run.
+
+Per-queue files (`<shard>/<hex>.db`) currently run without WAL, so they
+are atomically captured by a single file copy.
+
+## Block-level encryption
+
+The SQLCipher layer encrypts page contents but cannot hide:
+
+- Filesystem metadata: directory entries, file sizes, mtime/ctime.
+- WAL file size growth, which broadly correlates with write activity.
+- The fact that `MOLDD_DATA_DIR` exists at all.
+
+For deployments where these signals matter (state-actor adversary,
+seizure-resistance), wrap the data directory in full-disk encryption
+(LUKS) keyed independently from `MOLDD_MASTER_SEED`. Mount the LUKS
+volume only after operator attestation at boot.
+
+## Process-level limits
+
+The per-queue `*sql.DB` cache is capped at 256 entries and each entry
+consumes one file descriptor in the steady state. The master DB plus
+its WAL/-shm consume three more. Listeners, log files, and runtime
+housekeeping take roughly fifty. The default container `nofile` limit
+of 1024 leaves comfortable headroom; explicitly raise it if you tune
+the cache cap upward.
+
+```yaml
+# kubernetes example
+securityContext:
+  fsGroup: 65532
+resources:
+  limits:
+    ...
+# pod-level
+spec:
+  containers:
+  - name: moldd
+    securityContext:
+      capabilities:
+        drop: [ALL]
+    resources: ...
+    # nofile via kernel ulimit or sysctl
+```
+
+## Master seed handling
+
+`MOLDD_MASTER_SEED` is the root of trust for both the master database
+and every queue's derived key. Treat it like any other private signing
+key:
+
+- Never commit the value to source control.
+- Provision via the platform's secret manager (Kubernetes Secrets +
+  encryption-at-rest, Vault, AWS Secrets Manager, etc.). Mount it as an
+  environment variable for the process and not as a file the server
+  reads.
+- Rotate by spinning up a fresh deployment with a new seed, replicating
+  active queues out of the old store, and decommissioning the old node.
+  In-place rekey is not currently supported — the salt scheme expects
+  the seed to be stable for the lifetime of a queue.
+- Never log the seed or anything derived from it. The slog handlers
+  used by this server filter PII by convention; the seed itself never
+  reaches any log call site, but any tool added to the operational
+  pipeline must hold the same line.

--- a/server/cmd/moldd/main.go
+++ b/server/cmd/moldd/main.go
@@ -15,9 +15,12 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -33,7 +36,12 @@ import (
 const (
 	defaultAddr            = ":8080"
 	readHeaderTimeout      = 10 * time.Second
+	readTimeout            = 30 * time.Second
+	writeTimeout           = 60 * time.Second
+	idleTimeout            = 120 * time.Second
+	maxHeaderBytes         = 16 * 1024
 	shutdownTimeout        = 5 * time.Second
+	cleanupShutdownTimeout = 10 * time.Second
 	defaultCleanupInterval = 5 * time.Minute
 )
 
@@ -42,14 +50,21 @@ func main() {
 }
 
 func run() int {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: logLevelFromEnv()}))
+	slog.SetDefault(logger)
+
+	// Register signal handlers FIRST so a TERM that arrives during the
+	// brief startup window between "go func" and "signal.Notify" is not
+	// dropped to the OS default handler (which would kill us without
+	// graceful shutdown — visible during k8s scale-down storms).
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
 	store, closeStore, runCleanup, err := initStorage(logger)
 	if err != nil {
 		logger.Error("init storage", "err", err.Error())
 		return 1
 	}
-	defer func() { _ = closeStore() }()
 
 	mux := http.NewServeMux()
 	mux.Handle("GET /healthz", health.Handler())
@@ -58,27 +73,66 @@ func run() int {
 	api.Mount(mux)
 
 	srv := &http.Server{
-		Addr:              addr(),
 		Handler:           mux,
 		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
+		MaxHeaderBytes:    maxHeaderBytes,
+	}
+
+	// Bind explicitly so the actual listening address (which may differ
+	// from the configured one when MOLDD_ADDR=":0" is used in tests) is
+	// available for the Debug log below.
+	listener, err := net.Listen("tcp", addr())
+	if err != nil {
+		logger.Error("listen", "err", err.Error())
+		return 1
 	}
 
 	rootCtx, rootCancel := context.WithCancel(context.Background())
-	defer rootCancel()
+
+	// Ordered shutdown: cancel cleanup ctx → wait for cleanup goroutine to
+	// finish any in-flight Tick → only then close the store. Closing the
+	// store while a Tick is mid-query produces undefined behaviour in the
+	// SQL driver, so the WaitGroup gate is mandatory, not cosmetic. The
+	// wait is itself bounded so a wedged SQL operation cannot hold the
+	// process up forever; if the bound is exceeded we close the store
+	// anyway and let the runtime tear the goroutine down.
+	var cleanupWg sync.WaitGroup
+	defer func() {
+		rootCancel()
+		done := make(chan struct{})
+		go func() {
+			cleanupWg.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(cleanupShutdownTimeout):
+			logger.Warn("cleanup goroutine did not finish before timeout, forcing store close")
+		}
+		if err := closeStore(); err != nil {
+			logger.Warn("close store failed", "err", err.Error())
+		}
+	}()
+
 	if runCleanup != nil {
-		go runCleanup(rootCtx)
+		cleanupWg.Add(1)
+		go func() {
+			defer cleanupWg.Done()
+			runCleanup(rootCtx)
+		}()
 	}
 
 	serverErr := make(chan error, 1)
 	go func() {
-		logger.Info("moldd starting", "addr", srv.Addr)
-		if listenErr := srv.ListenAndServe(); listenErr != nil && !errors.Is(listenErr, http.ErrServerClosed) {
-			serverErr <- listenErr
+		logger.Info("moldd starting")
+		logger.Debug("http listener", "addr", listener.Addr().String())
+		if serveErr := srv.Serve(listener); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			serverErr <- serveErr
 		}
 	}()
-
-	stop := make(chan os.Signal, 1)
-	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
 	select {
 	case listenErr := <-serverErr:
@@ -103,6 +157,23 @@ func addr() string {
 		return v
 	}
 	return defaultAddr
+}
+
+// logLevelFromEnv reads MOLDD_LOG_LEVEL and returns the matching slog
+// level. Unknown or unset values default to info. This is the only knob
+// that exposes the listening address (Debug level), keeping operational
+// topology out of production logs by default.
+func logLevelFromEnv() slog.Level {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("MOLDD_LOG_LEVEL"))) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
 }
 
 // initStorage constructs the configured storage backend and (when persistent)

--- a/server/cmd/moldd/main.go
+++ b/server/cmd/moldd/main.go
@@ -50,6 +50,12 @@ func main() {
 }
 
 func run() int {
+	// Tighten the file-creation mask so any database files SQLCipher
+	// later opens land at 0600. The encrypted-at-rest property covers
+	// content; this covers metadata access (ctime, mtime, size) plus the
+	// raw ciphertext as a defence-in-depth measure against local readers.
+	syscall.Umask(0o077)
+
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: logLevelFromEnv()}))
 	slog.SetDefault(logger)
 

--- a/server/cmd/moldd/main.go
+++ b/server/cmd/moldd/main.go
@@ -107,20 +107,7 @@ func run() int {
 	// anyway and let the runtime tear the goroutine down.
 	var cleanupWg sync.WaitGroup
 	defer func() {
-		rootCancel()
-		done := make(chan struct{})
-		go func() {
-			cleanupWg.Wait()
-			close(done)
-		}()
-		select {
-		case <-done:
-		case <-time.After(cleanupShutdownTimeout):
-			logger.Warn("cleanup goroutine did not finish before timeout, forcing store close")
-		}
-		if err := closeStore(); err != nil {
-			logger.Warn("close store failed", "err", err.Error())
-		}
+		shutdownCleanly(rootCancel, &cleanupWg, closeStore, cleanupShutdownTimeout, logger)
 	}()
 
 	if runCleanup != nil {
@@ -163,6 +150,29 @@ func addr() string {
 		return v
 	}
 	return defaultAddr
+}
+
+// shutdownCleanly cancels the cleanup-runner context, waits for it to
+// drain (bounded by waitTimeout), and only then closes the store.
+// Extracted into a function so the timeout path is unit-testable
+// without spinning up the whole process. logger is optional for tests.
+func shutdownCleanly(rootCancel context.CancelFunc, cleanupWg *sync.WaitGroup, closeStore func() error, waitTimeout time.Duration, logger *slog.Logger) {
+	rootCancel()
+	done := make(chan struct{})
+	go func() {
+		cleanupWg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(waitTimeout):
+		if logger != nil {
+			logger.Warn("cleanup goroutine did not finish before timeout, forcing store close")
+		}
+	}
+	if err := closeStore(); err != nil && logger != nil {
+		logger.Warn("close store failed", "err", err.Error())
+	}
 }
 
 // logLevelFromEnv reads MOLDD_LOG_LEVEL and returns the matching slog

--- a/server/cmd/moldd/shutdown_test.go
+++ b/server/cmd/moldd/shutdown_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestShutdownCleanly_HappyPath verifies the bookkeeping when the
+// cleanup goroutine exits promptly: rootCancel must run, cleanupWg
+// must drain, closeStore must run exactly once.
+func TestShutdownCleanly_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-ctx.Done()
+	}()
+
+	closes := &atomic.Int64{}
+	closeStore := func() error {
+		closes.Add(1)
+		return nil
+	}
+
+	shutdownCleanly(cancel, &wg, closeStore, time.Second, nil)
+
+	if got := closes.Load(); got != 1 {
+		t.Errorf("closeStore calls: got %d, want 1", got)
+	}
+}
+
+// TestShutdownCleanly_TimeoutPath verifies the bound: even if the
+// cleanup goroutine never returns, shutdownCleanly closes the store
+// once the timeout elapses, instead of hanging the process forever.
+// This is the regression guard for the deadlock scenario flagged by
+// the second-round audit (S/C-01).
+func TestShutdownCleanly_TimeoutPath(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = ctx // unused but required to mirror real call shape
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	stuck := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		// Simulates a wedged Tick that ignores ctx cancellation.
+		<-stuck
+	}()
+	t.Cleanup(func() { close(stuck) })
+
+	closes := &atomic.Int64{}
+	closeStore := func() error {
+		closes.Add(1)
+		return nil
+	}
+
+	start := time.Now()
+	shutdownCleanly(cancel, &wg, closeStore, 50*time.Millisecond, nil)
+	elapsed := time.Since(start)
+
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("shutdownCleanly took %v, expected ≈ 50ms timeout", elapsed)
+	}
+	if got := closes.Load(); got != 1 {
+		t.Errorf("closeStore calls: got %d, want 1", got)
+	}
+}

--- a/server/go.mod
+++ b/server/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/mutecomm/go-sqlcipher/v4 v4.4.2
 	golang.org/x/crypto v0.50.0
 )
+
+require go.uber.org/goleak v1.3.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -8,5 +8,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=

--- a/server/internal/api/v1/main_test.go
+++ b/server/internal/api/v1/main_test.go
@@ -1,0 +1,17 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package v1_test
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain wraps the v1 HTTP-handler tests in goleak so any
+// httptest server that fails to close cleanly fails the suite.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/server/internal/api/v1/queues.go
+++ b/server/internal/api/v1/queues.go
@@ -11,7 +11,9 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/WissCore/moldchat/server/internal/auth"
@@ -22,6 +24,12 @@ import (
 // request is rejected. The cause is intentionally not surfaced to the
 // client, but it bumps the AuthFailureCount counter on Server.
 var errAuthDenied = errors.New("authorization denied")
+
+// queueIDRegex validates the format of queue identifiers received from
+// clients. New IDs are 32 unpadded base32 characters (RFC 4648 §6).
+// Rejecting malformed IDs early keeps storage lookups predictable and
+// closes off any path-traversal vector through the URL.
+var queueIDRegex = regexp.MustCompile(`^[A-Z2-7]{32}$`)
 
 // maxCreateBody bounds the JSON body for queue-creation requests.
 const maxCreateBody = 4 * 1024
@@ -57,11 +65,15 @@ func (s *Server) handleCreateQueue() http.Handler {
 		case errors.Is(err, queue.ErrInvalidX25519Key), errors.Is(err, queue.ErrInvalidEd25519Key):
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
+		case errors.Is(err, queue.ErrServiceCapacity):
+			writeError(w, http.StatusServiceUnavailable, "service at capacity")
+			return
 		case err != nil:
 			s.logServerError("create queue", err)
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
+		w.Header().Set("Cache-Control", "no-store")
 		writeJSON(w, http.StatusCreated, map[string]any{
 			"queue_id":   q.ID,
 			"expires_at": q.ExpiresAt.Format(time.RFC3339),
@@ -72,6 +84,10 @@ func (s *Server) handleCreateQueue() http.Handler {
 func (s *Server) handleAuthChallenge() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		queueID := r.PathValue("id")
+		if !queueIDRegex.MatchString(queueID) {
+			writeError(w, http.StatusNotFound, "queue not found")
+			return
+		}
 		if _, err := s.Storage.GetQueue(r.Context(), queueID); err != nil {
 			if errors.Is(err, queue.ErrQueueNotFound) {
 				writeError(w, http.StatusNotFound, "queue not found")
@@ -91,6 +107,7 @@ func (s *Server) handleAuthChallenge() http.Handler {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
+		w.Header().Set("Cache-Control", "no-store")
 		writeJSON(w, http.StatusOK, map[string]any{
 			"nonce":      base64.StdEncoding.EncodeToString(nonce),
 			"expires_at": expiresAt.Format(time.RFC3339),
@@ -100,6 +117,16 @@ func (s *Server) handleAuthChallenge() http.Handler {
 
 func (s *Server) handlePutMessage() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Validate the queue_id BEFORE reading the body. This stops the
+		// trivial DoS where an attacker sends MaxBlobSize bodies to
+		// guaranteed-malformed IDs: we'd otherwise consume bandwidth, RAM,
+		// and CPU for nothing. Cheap path-only check first, expensive body
+		// read only if the URL is well-formed.
+		queueID := r.PathValue("id")
+		if !queueIDRegex.MatchString(queueID) {
+			writeError(w, http.StatusNotFound, "queue not found")
+			return
+		}
 		r.Body = http.MaxBytesReader(w, r.Body, queue.MaxBlobSize+1)
 		blob, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -110,7 +137,6 @@ func (s *Server) handlePutMessage() http.Handler {
 			writeError(w, http.StatusRequestEntityTooLarge, "blob exceeds maximum size")
 			return
 		}
-		queueID := r.PathValue("id")
 		m, err := s.Storage.PutMessage(r.Context(), queueID, blob)
 		switch {
 		case errors.Is(err, queue.ErrQueueNotFound):
@@ -122,11 +148,15 @@ func (s *Server) handlePutMessage() http.Handler {
 		case errors.Is(err, queue.ErrBlobTooLarge):
 			writeError(w, http.StatusRequestEntityTooLarge, "blob exceeds maximum size")
 			return
+		case errors.Is(err, queue.ErrServiceCapacity):
+			writeError(w, http.StatusServiceUnavailable, "service at capacity")
+			return
 		case err != nil:
 			s.logServerError("put message", err)
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
+		w.Header().Set("Cache-Control", "no-store")
 		writeJSON(w, http.StatusAccepted, map[string]any{
 			"message_id":  m.ID,
 			"accepted_at": m.ReceivedAt.Format(time.RFC3339),
@@ -142,6 +172,10 @@ func (s *Server) handleListMessages() http.Handler {
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		queueID := r.PathValue("id")
+		if !queueIDRegex.MatchString(queueID) {
+			writeError(w, http.StatusNotFound, "queue not found")
+			return
+		}
 		q, err := s.Storage.GetQueue(r.Context(), queueID)
 		if errors.Is(err, queue.ErrQueueNotFound) {
 			writeError(w, http.StatusNotFound, "queue not found")
@@ -171,6 +205,7 @@ func (s *Server) handleListMessages() http.Handler {
 				TS:   m.ReceivedAt.Format(time.RFC3339),
 			}
 		}
+		w.Header().Set("Cache-Control", "no-store")
 		writeJSON(w, http.StatusOK, map[string]any{
 			"messages": out,
 			"has_more": hasMore,
@@ -183,6 +218,10 @@ func (s *Server) handleDeleteMessage() http.Handler {
 		queueID := r.PathValue("id")
 		messageID := r.PathValue("mid")
 
+		if !queueIDRegex.MatchString(queueID) {
+			writeError(w, http.StatusNotFound, "queue not found")
+			return
+		}
 		q, err := s.Storage.GetQueue(r.Context(), queueID)
 		if errors.Is(err, queue.ErrQueueNotFound) {
 			writeError(w, http.StatusNotFound, "queue not found")
@@ -208,6 +247,7 @@ func (s *Server) handleDeleteMessage() http.Handler {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
+		w.Header().Set("Cache-Control", "no-store")
 		w.WriteHeader(http.StatusNoContent)
 	})
 }
@@ -220,6 +260,13 @@ func (s *Server) handleDeleteMessage() http.Handler {
 func (s *Server) authorizeOwner(r *http.Request, q *queue.Queue) error {
 	sig, pubkey, nonce, err := auth.ParseAuthorization(r.Header.Get("Authorization"))
 	if err != nil {
+		return errAuthDenied
+	}
+	// Explicit length guard: subtle.ConstantTimeCompare returns 1 when both
+	// inputs are empty, which would be a "match" if either side were ever
+	// nil. Verify catches that downstream, but failing here keeps the check
+	// single-step.
+	if len(pubkey) != ed25519.PublicKeySize || len(q.OwnerEd25519Pub) != ed25519.PublicKeySize {
 		return errAuthDenied
 	}
 	if subtle.ConstantTimeCompare(pubkey, q.OwnerEd25519Pub) != 1 {
@@ -242,12 +289,18 @@ func (s *Server) logServerError(op string, err error) {
 	s.Logger.Error("server error", "op", op, "err", err.Error())
 }
 
+// writeJSON commits the headers and best-effort encodes body as JSON.
+// Encode failures here mean the connection broke after the status line
+// was already sent; we cannot recover, but we do want a breadcrumb. The
+// debug call routes through slog.Default(), which the binary's main()
+// is responsible for setting via slog.SetDefault — without that wiring
+// the message goes to the stdlib default handler at info level and is
+// silently dropped.
 func writeJSON(w http.ResponseWriter, status int, body any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(body); err != nil {
-		// Response already partially written; nothing actionable for the client.
-		return
+		slog.Default().Debug("response encode failed", "err", err.Error())
 	}
 }
 

--- a/server/internal/api/v1/queues.go
+++ b/server/internal/api/v1/queues.go
@@ -186,7 +186,7 @@ func (s *Server) handleListMessages() http.Handler {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
-		if authErr := s.authorizeOwner(r, q); authErr != nil {
+		if authErr := s.authorizeOwner(r, q, ""); authErr != nil {
 			s.AuthFailureCount.Add(1)
 			writeError(w, http.StatusUnauthorized, "unauthorized")
 			return
@@ -232,7 +232,7 @@ func (s *Server) handleDeleteMessage() http.Handler {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
-		if authErr := s.authorizeOwner(r, q); authErr != nil {
+		if authErr := s.authorizeOwner(r, q, messageID); authErr != nil {
 			s.AuthFailureCount.Add(1)
 			writeError(w, http.StatusUnauthorized, "unauthorized")
 			return
@@ -254,10 +254,13 @@ func (s *Server) handleDeleteMessage() http.Handler {
 
 // authorizeOwner verifies the Ed25519-Sig challenge-response in the
 // Authorization header against the queue's registered owner public key.
-// It returns nil on success and errAuthDenied for every failure mode;
-// the cause is intentionally collapsed so the response does not reveal
+// resourceID is the message identifier when present in the URL (DELETE)
+// and the empty string otherwise; it binds the signature to the
+// targeted resource without depending on the literal request path.
+// Returns nil on success and errAuthDenied for every failure mode; the
+// cause is intentionally collapsed so the response does not reveal
 // which check failed.
-func (s *Server) authorizeOwner(r *http.Request, q *queue.Queue) error {
+func (s *Server) authorizeOwner(r *http.Request, q *queue.Queue, resourceID string) error {
 	sig, pubkey, nonce, err := auth.ParseAuthorization(r.Header.Get("Authorization"))
 	if err != nil {
 		return errAuthDenied
@@ -275,7 +278,7 @@ func (s *Server) authorizeOwner(r *http.Request, q *queue.Queue) error {
 	if verifyErr := s.Auth.Verify(
 		ed25519.PublicKey(pubkey),
 		nonce, sig,
-		q.ID, r.Method, r.URL.Path,
+		q.ID, r.Method, resourceID,
 	); verifyErr != nil {
 		return errAuthDenied
 	}
@@ -296,8 +299,16 @@ func (s *Server) logServerError(op string, err error) {
 // is responsible for setting via slog.SetDefault — without that wiring
 // the message goes to the stdlib default handler at info level and is
 // silently dropped.
+//
+// Headers set:
+//   - Content-Type: application/json
+//   - X-Content-Type-Options: nosniff to forbid MIME sniffing on any
+//     response a user agent might decide to render. We never serve
+//     HTML from this endpoint, but the header is the standard OWASP
+//     defence and costs nothing.
 func writeJSON(w http.ResponseWriter, status int, body any) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(body); err != nil {
 		slog.Default().Debug("response encode failed", "err", err.Error())

--- a/server/internal/api/v1/queues_test.go
+++ b/server/internal/api/v1/queues_test.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"testing"
 
@@ -126,14 +125,12 @@ func fetchNonce(t *testing.T, baseURL, queueID string) []byte {
 }
 
 // signedRequest builds a request authenticated with a fresh challenge.
-func signedRequest(t *testing.T, baseURL, queueID, method, target string, owner ownerCreds) *http.Request {
+// resourceID binds the signature to the targeted message id for DELETE
+// requests; pass empty string for list/auth-challenge.
+func signedRequest(t *testing.T, baseURL, queueID, method, target, resourceID string, owner ownerCreds) *http.Request {
 	t.Helper()
 	nonce := fetchNonce(t, baseURL, queueID)
-	u, err := url.Parse(baseURL + target)
-	if err != nil {
-		t.Fatalf("parse url: %v", err)
-	}
-	payload := auth.CanonicalPayload(nonce, queueID, method, u.Path)
+	payload := auth.CanonicalPayload(nonce, queueID, method, resourceID)
 	sig := ed25519.Sign(owner.ed25519Pri, payload)
 
 	req, err := http.NewRequest(method, baseURL+target, nil)
@@ -207,7 +204,7 @@ func TestPutMessage_RoundTrip(t *testing.T) {
 	}
 
 	req := signedRequest(t, srv.URL, queueID, http.MethodGet,
-		"/v1/queues/"+queueID+"/messages", owner)
+		"/v1/queues/"+queueID+"/messages", "", owner)
 	getResp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("get: %v", err)
@@ -279,7 +276,7 @@ func TestListMessages_Unauthorized(t *testing.T) {
 
 	intruder := newOwner(t)
 	req := signedRequest(t, srv.URL, queueID, http.MethodGet,
-		"/v1/queues/"+queueID+"/messages", intruder)
+		"/v1/queues/"+queueID+"/messages", "", intruder)
 	wrongResp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("do: %v", err)
@@ -297,7 +294,7 @@ func TestListMessages_RejectsReplay(t *testing.T) {
 	queueID := createQueue(t, srv.URL, owner)
 
 	req := signedRequest(t, srv.URL, queueID, http.MethodGet,
-		"/v1/queues/"+queueID+"/messages", owner)
+		"/v1/queues/"+queueID+"/messages", "", owner)
 	first, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("first do: %v", err)
@@ -350,7 +347,7 @@ func TestDeleteMessage_RoundTrip(t *testing.T) {
 	_ = putResp.Body.Close()
 
 	req := signedRequest(t, srv.URL, queueID, http.MethodDelete,
-		"/v1/queues/"+queueID+"/messages/"+puts.MessageID, owner)
+		"/v1/queues/"+queueID+"/messages/"+puts.MessageID, puts.MessageID, owner)
 	delResp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("delete: %v", err)
@@ -380,7 +377,7 @@ func TestListMessages_RejectsTamperedMethod(t *testing.T) {
 
 	// Sign for GET, submit as DELETE.
 	req := signedRequest(t, srv.URL, queueID, http.MethodGet,
-		"/v1/queues/"+queueID+"/messages/"+puts.MessageID, owner)
+		"/v1/queues/"+queueID+"/messages/"+puts.MessageID, puts.MessageID, owner)
 	req.Method = http.MethodDelete
 	req.URL.Path = "/v1/queues/" + queueID + "/messages/" + puts.MessageID
 

--- a/server/internal/api/v1/queues_test.go
+++ b/server/internal/api/v1/queues_test.go
@@ -430,6 +430,88 @@ func TestListMessages_MalformedAuthorizationHeader(t *testing.T) {
 	}
 }
 
+// TestMessages_RejectMalformedQueueID covers the API-level reaction to
+// queue identifiers that don't match the on-the-wire format. Anything
+// that is not 32 base32 characters must collapse to 404 so we don't
+// leak validation-vs-lookup distinctions.
+func TestMessages_RejectMalformedQueueID(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	cases := []string{
+		"too-short",
+		"contains-lowercase-not-base32",
+		strings.Repeat("A", 33),
+		"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1", // '1' is outside base32 RFC4648 §6
+	}
+	for _, id := range cases {
+		t.Run(id, func(t *testing.T) {
+			t.Parallel()
+			type probe struct {
+				method, target string
+			}
+			probes := []probe{
+				{http.MethodGet, "/v1/queues/" + id + "/messages"},
+				{http.MethodGet, "/v1/queues/" + id + "/auth-challenge"},
+				{http.MethodDelete, "/v1/queues/" + id + "/messages/SOMEMSG"},
+			}
+			for _, p := range probes {
+				req, err := http.NewRequest(p.method, srv.URL+p.target, nil)
+				if err != nil {
+					t.Fatalf("new request %s %s: %v", p.method, p.target, err)
+				}
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					t.Fatalf("%s %s: %v", p.method, p.target, err)
+				}
+				_ = resp.Body.Close()
+				if resp.StatusCode != http.StatusNotFound {
+					t.Errorf("%s %s: got %d, want 404", p.method, p.target, resp.StatusCode)
+				}
+			}
+		})
+	}
+}
+
+// TestCreateQueue_ServiceCapacity verifies that filling the in-memory
+// backend to MaxQueues makes the next POST return 503 Service
+// Unavailable rather than leaking a 500 internal error. Heavy: skipped
+// in -short. Reuses a single owner across iterations so the cap path
+// (not crypto keygen) is what's exercised.
+func TestCreateQueue_ServiceCapacity(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping capacity test in -short mode")
+	}
+	srv := newTestServer(t)
+	owner := newOwner(t)
+	body := map[string]string{
+		"owner_x25519_pubkey":  base64.StdEncoding.EncodeToString(owner.x25519Pub),
+		"owner_ed25519_pubkey": base64.StdEncoding.EncodeToString(owner.ed25519Pub),
+	}
+	raw, _ := json.Marshal(body)
+
+	for i := 0; i < memory.MaxQueues; i++ {
+		resp, err := http.Post(srv.URL+"/v1/queues", "application/json", bytes.NewReader(raw))
+		if err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("seed %d: got %d, want 201", i, resp.StatusCode)
+		}
+	}
+
+	resp, err := http.Post(srv.URL+"/v1/queues", "application/json", bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("over-cap post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("over-cap status: got %d, want 503", resp.StatusCode)
+	}
+}
+
 // TestAuthFailureCount_BumpsOnDenial verifies the server-side aggregate
 // counter is incremented on auth failure.
 func TestAuthFailureCount_BumpsOnDenial(t *testing.T) {

--- a/server/internal/api/v1/queues_test.go
+++ b/server/internal/api/v1/queues_test.go
@@ -440,6 +440,17 @@ func TestMessages_RejectMalformedQueueID(t *testing.T) {
 		"contains-lowercase-not-base32",
 		strings.Repeat("A", 33),
 		"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1", // '1' is outside base32 RFC4648 §6
+		// Path-traversal-ish probes the regex must reject. The HTTP
+		// router already rejects multi-segment paths, but encoded
+		// variants that survive normalisation (or future routing
+		// changes) must still hit our format guard rather than the
+		// filesystem. Null bytes and other characters that Go's URL
+		// parser refuses are covered by the parser itself, not this
+		// regex.
+		"..",
+		strings.Repeat(".", 32),
+		"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%2F",
+		"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-",
 	}
 	for _, id := range cases {
 		t.Run(id, func(t *testing.T) {

--- a/server/internal/auth/auth.go
+++ b/server/internal/auth/auth.go
@@ -163,6 +163,18 @@ func (i *Issuer) Verify(pubkey ed25519.PublicKey, nonce, sig []byte, queueID, me
 
 // canonicalPayload returns the bytes that must be signed by the client.
 // The format is documented at the top of this package.
+//
+// Framing invariant: the 0x00 separator only yields an unambiguous
+// canonical form because none of the current fields can contain a
+// 0x00 byte in production. nonce is exact 32 random bytes (never all
+// zero in practice but could be — separators surrounding it disambiguate
+// regardless), queueID and resourceID are validated against
+// `^[A-Z2-7]+$` at the API boundary, and method comes from
+// http.Request.Method which is a HTTP token (RFC 7230). If a future
+// caller adds a field that can carry arbitrary user-controlled bytes,
+// this format must move to a length-prefixed framing — otherwise two
+// distinct (field-tuple) inputs could produce the same byte string and
+// reuse a single Ed25519 signature across two different operations.
 func canonicalPayload(nonce []byte, queueID, method, resourceID string) []byte {
 	out := make([]byte, 0, len(domainTag)+1+len(nonce)+1+len(queueID)+1+len(method)+1+len(resourceID))
 	out = append(out, domainTag...)

--- a/server/internal/auth/auth.go
+++ b/server/internal/auth/auth.go
@@ -86,8 +86,10 @@ func NewIssuer() *Issuer {
 
 // Issue returns a fresh nonce together with its expiry timestamp.
 // The nonce is single-use and remembered until Verify consumes it or it
-// expires. Each call sweeps expired entries; if the live set is at the
-// MaxOutstandingNonces cap after sweeping, ErrIssuerSaturated is returned.
+// expires. Sweeping of expired entries is amortised: it runs only when
+// the live set has hit the MaxOutstandingNonces cap, which keeps the
+// fast path O(1) under normal load. After sweeping, if the cap is still
+// reached, ErrIssuerSaturated is returned.
 func (i *Issuer) Issue() (nonce []byte, expiresAt time.Time, err error) {
 	nonce = make([]byte, NonceBytes)
 	if _, err = rand.Read(nonce); err != nil {
@@ -98,13 +100,15 @@ func (i *Issuer) Issue() (nonce []byte, expiresAt time.Time, err error) {
 	defer i.mu.Unlock()
 
 	now := i.now()
-	for k, exp := range i.issued {
-		if !exp.After(now) {
-			delete(i.issued, k)
-		}
-	}
 	if len(i.issued) >= MaxOutstandingNonces {
-		return nil, time.Time{}, ErrIssuerSaturated
+		for k, exp := range i.issued {
+			if !exp.After(now) {
+				delete(i.issued, k)
+			}
+		}
+		if len(i.issued) >= MaxOutstandingNonces {
+			return nil, time.Time{}, ErrIssuerSaturated
+		}
 	}
 
 	expiresAt = now.Add(NonceTTL)
@@ -172,15 +176,22 @@ func CanonicalPayload(nonce []byte, queueID, method, path string) []byte {
 }
 
 // ParseAuthorization parses an "ED25519-Sig <sig_b64>,<pubkey_b64>,<nonce_b64>"
-// header into raw signature, public-key, and nonce bytes.
+// header into raw signature, public-key, and nonce bytes. The auth-scheme
+// token is matched case-insensitively per RFC 7235 §2.1, and the
+// separator between the scheme and the credentials may be any run of
+// SP/HTAB characters as the same RFC permits.
 func ParseAuthorization(header string) (sig, pubkey, nonce []byte, err error) {
 	if header == "" {
 		return nil, nil, nil, ErrAuthorizationMissing
 	}
-	rest, ok := strings.CutPrefix(header, AuthScheme+" ")
-	if !ok {
+	sep := strings.IndexAny(header, " \t")
+	if sep < 0 {
 		return nil, nil, nil, ErrAuthorizationMalformed
 	}
+	if !strings.EqualFold(header[:sep], AuthScheme) {
+		return nil, nil, nil, ErrAuthorizationMalformed
+	}
+	rest := strings.TrimLeft(header[sep+1:], " \t")
 	parts := strings.Split(rest, ",")
 	if len(parts) != 3 {
 		return nil, nil, nil, ErrAuthorizationMalformed

--- a/server/internal/auth/auth.go
+++ b/server/internal/auth/auth.go
@@ -11,9 +11,10 @@
 //     Server returns a fresh 32-byte nonce with a 30-second TTL.
 //  2. Client signs the canonical payload
 //     "moldd-v1-auth" || 0x00 || nonce || 0x00 || queue_id || 0x00 ||
-//     method || 0x00 || path
+//     method || 0x00 || resource_id
 //     using the Ed25519 private key whose public half was registered when
-//     the queue was created.
+//     the queue was created. resource_id is the message identifier for
+//     DELETE operations and the empty string for everything else.
 //  3. Client sends the request with header
 //     Authorization: ED25519-Sig <signature_b64>,<pubkey_b64>,<nonce_b64>
 //     The header format is comma-separated bare base64 fields rather than
@@ -23,6 +24,13 @@
 //  4. Server re-derives the canonical payload, checks the supplied pubkey
 //     matches the one registered with the queue (constant-time), verifies
 //     the signature, and burns the nonce so it cannot be replayed.
+//
+// The signed payload deliberately omits the URL path: HTTP intermediaries
+// (Cloudflare, reverse proxies, the Xray frontend) routinely re-normalise
+// trailing slashes, percent-encoding, and dot segments, which would cause
+// signatures to mismatch through no fault of the client. The triple of
+// (queue_id, method, resource_id) uniquely identifies the protected
+// operation without depending on the literal request path.
 //
 // The nonce store is in-memory, has a hard cap on outstanding entries,
 // and is GCed lazily on each Issue call.
@@ -117,11 +125,11 @@ func (i *Issuer) Issue() (nonce []byte, expiresAt time.Time, err error) {
 }
 
 // Verify checks the signature against pubkey for the canonical payload
-// derived from (nonce, queueID, method, path). On success the nonce is
-// burned so subsequent calls return ErrReplay. The nonce is also burned
-// on signature failure: a single nonce must never authorise more than
-// one verification attempt, regardless of outcome.
-func (i *Issuer) Verify(pubkey ed25519.PublicKey, nonce, sig []byte, queueID, method, path string) error {
+// derived from (nonce, queueID, method, resourceID). On success the
+// nonce is burned so subsequent calls return ErrReplay. The nonce is
+// also burned on signature failure: a single nonce must never authorise
+// more than one verification attempt, regardless of outcome.
+func (i *Issuer) Verify(pubkey ed25519.PublicKey, nonce, sig []byte, queueID, method, resourceID string) error {
 	if len(pubkey) != ed25519.PublicKeySize {
 		return ErrSignatureInvalid
 	}
@@ -144,7 +152,7 @@ func (i *Issuer) Verify(pubkey ed25519.PublicKey, nonce, sig []byte, queueID, me
 		return ErrReplay
 	}
 
-	payload := canonicalPayload(nonce, queueID, method, path)
+	payload := canonicalPayload(nonce, queueID, method, resourceID)
 	if !ed25519.Verify(pubkey, payload, sig) {
 		delete(i.issued, string(nonce))
 		return ErrSignatureInvalid
@@ -155,8 +163,8 @@ func (i *Issuer) Verify(pubkey ed25519.PublicKey, nonce, sig []byte, queueID, me
 
 // canonicalPayload returns the bytes that must be signed by the client.
 // The format is documented at the top of this package.
-func canonicalPayload(nonce []byte, queueID, method, path string) []byte {
-	out := make([]byte, 0, len(domainTag)+1+len(nonce)+1+len(queueID)+1+len(method)+1+len(path))
+func canonicalPayload(nonce []byte, queueID, method, resourceID string) []byte {
+	out := make([]byte, 0, len(domainTag)+1+len(nonce)+1+len(queueID)+1+len(method)+1+len(resourceID))
 	out = append(out, domainTag...)
 	out = append(out, separator)
 	out = append(out, nonce...)
@@ -165,14 +173,16 @@ func canonicalPayload(nonce []byte, queueID, method, path string) []byte {
 	out = append(out, separator)
 	out = append(out, method...)
 	out = append(out, separator)
-	out = append(out, path...)
+	out = append(out, resourceID...)
 	return out
 }
 
 // CanonicalPayload exposes the canonical signing payload for clients and
 // integration tests. Callers should not mutate the returned slice.
-func CanonicalPayload(nonce []byte, queueID, method, path string) []byte {
-	return canonicalPayload(nonce, queueID, method, path)
+// resourceID is the message identifier for DELETE operations and the
+// empty string otherwise.
+func CanonicalPayload(nonce []byte, queueID, method, resourceID string) []byte {
+	return canonicalPayload(nonce, queueID, method, resourceID)
 }
 
 // ParseAuthorization parses an "ED25519-Sig <sig_b64>,<pubkey_b64>,<nonce_b64>"

--- a/server/internal/auth/auth_bench_test.go
+++ b/server/internal/auth/auth_bench_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package auth_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+
+	"github.com/WissCore/moldchat/server/internal/auth"
+)
+
+// BenchmarkVerify measures the cost of a successful challenge-response
+// verification including nonce lookup, Ed25519 verify, and replay
+// burning. This is the single hottest auth path on the server and
+// regressions here directly cap owner-only request throughput.
+func BenchmarkVerify(b *testing.B) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		b.Fatalf("ed25519 keygen: %v", err)
+	}
+	iss := auth.NewIssuer()
+	queueID, method, resourceID := "Q1", "GET", ""
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		nonce, _, err := iss.Issue()
+		if err != nil {
+			b.Fatalf("Issue: %v", err)
+		}
+		sig := ed25519.Sign(priv, auth.CanonicalPayload(nonce, queueID, method, resourceID))
+		if err := iss.Verify(pub, nonce, sig, queueID, method, resourceID); err != nil {
+			b.Fatalf("Verify: %v", err)
+		}
+	}
+}
+
+// BenchmarkParseAuthorization measures the cost of header parsing on
+// the request hot path. Every owner-only request runs this once; a
+// regression here applies a tax to every authenticated call.
+func BenchmarkParseAuthorization(b *testing.B) {
+	sig := make([]byte, ed25519.SignatureSize)
+	pubkey := make([]byte, ed25519.PublicKeySize)
+	nonce := make([]byte, auth.NonceBytes)
+	header := auth.FormatAuthorization(sig, pubkey, nonce)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _, _ = auth.ParseAuthorization(header)
+	}
+}

--- a/server/internal/auth/auth_fuzz_test.go
+++ b/server/internal/auth/auth_fuzz_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package auth_test
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"testing"
+
+	"github.com/WissCore/moldchat/server/internal/auth"
+)
+
+// FuzzParseAuthorization feeds arbitrary header strings into the
+// Authorization parser. Beyond "no panic", the parser must return
+// only the documented sentinel errors so a future refactor cannot
+// accidentally leak a different error type to the API layer (where
+// it would surface as 500 instead of 401).
+func FuzzParseAuthorization(f *testing.F) {
+	seeds := []string{
+		"",
+		"ED25519-Sig YWFh,YmJi,Y2Nj",
+		"ed25519-sig\tYWFh,YmJi,Y2Nj",
+		"Bearer abc",
+		"ED25519-Sig only",
+		"ED25519-Sig a,b,c,d,e",
+		"ED25519-Sig !!!,!!!,!!!",
+		"ED25519-Sig\nbroken",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, header string) {
+		_, _, _, err := auth.ParseAuthorization(header)
+		if err == nil {
+			return
+		}
+		if !errors.Is(err, auth.ErrAuthorizationMissing) &&
+			!errors.Is(err, auth.ErrAuthorizationMalformed) {
+			t.Errorf("unexpected error type for header %q: %T %v", header, err, err)
+		}
+	})
+}
+
+// FuzzCanonicalPayload verifies the two invariants Ed25519.Verify
+// relies on for the auth contract: (1) length lower bound — the
+// returned slice is at least as long as the concatenation of inputs,
+// (2) determinism — the same inputs produce the same bytes. The
+// exact format is internal, but a non-deterministic canonical payload
+// would silently break every signed request after a refactor.
+//
+// Note on separator framing: the implementation uses 0x00 as a field
+// delimiter without length prefixes. Our wire-level inputs (queue id,
+// message id, method) cannot contain 0x00 because they are validated
+// against base32 / HTTP-token alphabets at the API boundary, so the
+// framing is unambiguous in practice. This test would still pass on
+// inputs with embedded 0x00; if a future field could carry arbitrary
+// bytes, the framing must move to length-prefixed form.
+func FuzzCanonicalPayload(f *testing.F) {
+	f.Add(make([]byte, auth.NonceBytes), "Q", "GET", "")
+	f.Add(make([]byte, auth.NonceBytes), "Q1", "DELETE", "MSG1")
+	f.Fuzz(func(t *testing.T, nonce []byte, queueID, method, resourceID string) {
+		got := auth.CanonicalPayload(nonce, queueID, method, resourceID)
+		if len(got) < len(nonce)+len(queueID)+len(method)+len(resourceID) {
+			t.Errorf("payload shorter than concatenation of inputs")
+		}
+		again := auth.CanonicalPayload(nonce, queueID, method, resourceID)
+		if !bytes.Equal(got, again) {
+			t.Errorf("canonical payload not deterministic")
+		}
+	})
+}
+
+// FuzzVerify feeds random pubkeys, nonces, and signatures at Verify
+// to confirm it never panics on malformed inputs and consistently
+// rejects garbage with one of the documented sentinel errors. A
+// successful verification on a fresh issuer (no nonce ever issued)
+// would also be a contract violation: the only possible non-error
+// path requires Issue() to have run first.
+func FuzzVerify(f *testing.F) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		f.Fatalf("ed25519 keygen: %v", err)
+	}
+	f.Add([]byte(pub), make([]byte, auth.NonceBytes), make([]byte, ed25519.SignatureSize), "Q", "GET", "")
+	f.Add([]byte("short-pubkey"), []byte("short-nonce"), []byte("short-sig"), "", "", "")
+	f.Fuzz(func(t *testing.T, pubkey, nonce, sig []byte, queueID, method, resourceID string) {
+		iss := auth.NewIssuer()
+		err := iss.Verify(ed25519.PublicKey(pubkey), nonce, sig, queueID, method, resourceID)
+		if err == nil {
+			t.Errorf("Verify on fresh issuer must fail (no nonce ever issued)")
+			return
+		}
+		if !errors.Is(err, auth.ErrSignatureInvalid) &&
+			!errors.Is(err, auth.ErrAuthorizationMalformed) &&
+			!errors.Is(err, auth.ErrReplay) {
+			t.Errorf("unexpected error type: %T %v", err, err)
+		}
+	})
+}

--- a/server/internal/health/health.go
+++ b/server/internal/health/health.go
@@ -8,6 +8,7 @@ package health
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"runtime/debug"
 )
@@ -26,6 +27,8 @@ func Handler() http.Handler {
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(body)
+		if err := json.NewEncoder(w).Encode(body); err != nil {
+			slog.Default().Debug("healthz encode failed", "err", err.Error())
+		}
 	})
 }

--- a/server/internal/queue/queue.go
+++ b/server/internal/queue/queue.go
@@ -12,12 +12,17 @@ package queue
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/base32"
 	"errors"
 	"time"
 
 	"golang.org/x/crypto/curve25519"
 )
+
+// allZeroX25519 is a sentinel zero point used by the constant-time
+// equality check in ValidateOwnerKeys.
+var allZeroX25519 = make([]byte, X25519PubKeyBytes)
 
 // Sizing and limits for queues and messages.
 const (
@@ -90,26 +95,18 @@ func generateID(n int) (string, error) {
 // expected sizes for X25519 and Ed25519 public keys, and rejects the
 // trivially-bad all-zero X25519 point. Full low-order point screening
 // will land alongside the first DH consumer so it is exercised on the
-// same code path that uses the key.
+// same code path that uses the key. The all-zero comparison runs in
+// constant time so this validator does not become a timing oracle for
+// adversarial X25519 inputs once the queue is in production.
 func ValidateOwnerKeys(k OwnerKeys) error {
 	if len(k.X25519Pub) != X25519PubKeyBytes {
 		return ErrInvalidX25519Key
 	}
-	if isAllZero(k.X25519Pub) {
+	if subtle.ConstantTimeCompare(k.X25519Pub, allZeroX25519) == 1 {
 		return ErrInvalidX25519Key
 	}
 	if len(k.Ed25519Pub) != Ed25519PubKeyBytes {
 		return ErrInvalidEd25519Key
 	}
 	return nil
-}
-
-// isAllZero returns true iff every byte of b is zero.
-func isAllZero(b []byte) bool {
-	for _, x := range b {
-		if x != 0 {
-			return false
-		}
-	}
-	return true
 }

--- a/server/internal/queue/queue.go
+++ b/server/internal/queue/queue.go
@@ -39,6 +39,7 @@ var (
 	ErrEmptyBlob         = errors.New("blob is empty")
 	ErrInvalidX25519Key  = errors.New("x25519 public key must be 32 bytes")
 	ErrInvalidEd25519Key = errors.New("ed25519 public key must be 32 bytes")
+	ErrServiceCapacity   = errors.New("service at capacity")
 )
 
 // OwnerKeys is the pair of public keys registered with a queue at creation
@@ -86,13 +87,29 @@ func generateID(n int) (string, error) {
 }
 
 // ValidateOwnerKeys rejects key pairs whose lengths do not match the
-// expected sizes for X25519 and Ed25519 public keys.
+// expected sizes for X25519 and Ed25519 public keys, and rejects the
+// trivially-bad all-zero X25519 point. Full low-order point screening
+// will land alongside the first DH consumer so it is exercised on the
+// same code path that uses the key.
 func ValidateOwnerKeys(k OwnerKeys) error {
 	if len(k.X25519Pub) != X25519PubKeyBytes {
+		return ErrInvalidX25519Key
+	}
+	if isAllZero(k.X25519Pub) {
 		return ErrInvalidX25519Key
 	}
 	if len(k.Ed25519Pub) != Ed25519PubKeyBytes {
 		return ErrInvalidEd25519Key
 	}
 	return nil
+}
+
+// isAllZero returns true iff every byte of b is zero.
+func isAllZero(b []byte) bool {
+	for _, x := range b {
+		if x != 0 {
+			return false
+		}
+	}
+	return true
 }

--- a/server/internal/queue/queue_test.go
+++ b/server/internal/queue/queue_test.go
@@ -45,8 +45,10 @@ func TestNewMessageID_Length(t *testing.T) {
 func TestValidateOwnerKeys(t *testing.T) {
 	t.Parallel()
 
+	nonZeroX := make([]byte, queue.X25519PubKeyBytes)
+	nonZeroX[0] = 1
 	good := queue.OwnerKeys{
-		X25519Pub:  make([]byte, queue.X25519PubKeyBytes),
+		X25519Pub:  nonZeroX,
 		Ed25519Pub: make([]byte, queue.Ed25519PubKeyBytes),
 	}
 	if err := queue.ValidateOwnerKeys(good); err != nil {
@@ -57,6 +59,12 @@ func TestValidateOwnerKeys(t *testing.T) {
 	shortX.X25519Pub = make([]byte, 31)
 	if err := queue.ValidateOwnerKeys(shortX); !errors.Is(err, queue.ErrInvalidX25519Key) {
 		t.Errorf("short X25519: got %v, want ErrInvalidX25519Key", err)
+	}
+
+	zeroX := good
+	zeroX.X25519Pub = make([]byte, queue.X25519PubKeyBytes)
+	if err := queue.ValidateOwnerKeys(zeroX); !errors.Is(err, queue.ErrInvalidX25519Key) {
+		t.Errorf("all-zero X25519: got %v, want ErrInvalidX25519Key", err)
 	}
 
 	shortEd := good

--- a/server/internal/storage/cleanup/cleanup.go
+++ b/server/internal/storage/cleanup/cleanup.go
@@ -58,6 +58,9 @@ func (r *Runner) Tick(ctx context.Context) int {
 	}
 	ids, err := r.Cleaner.ExpiredQueueIDs(ctx, now)
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return 0
+		}
 		r.log(ctx, slog.LevelError, "list expired queues", "err", err.Error())
 		return 0
 	}
@@ -66,6 +69,9 @@ func (r *Runner) Tick(ctx context.Context) int {
 		if err := r.Cleaner.DeleteQueue(ctx, id); err != nil {
 			if errors.Is(err, queue.ErrQueueNotFound) {
 				continue
+			}
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return deleted
 			}
 			r.log(ctx, slog.LevelError, "delete expired queue", "err", err.Error())
 			continue

--- a/server/internal/storage/cleanup/cleanup_test.go
+++ b/server/internal/storage/cleanup/cleanup_test.go
@@ -23,9 +23,19 @@ type fakeCleaner struct {
 	deleted    []string
 	listErr    error
 	deleteErrs map[string]error
+	// listDelay simulates a slow Tick so tests can race a context
+	// cancel against an in-flight ExpiredQueueIDs call.
+	listDelay time.Duration
 }
 
-func (f *fakeCleaner) ExpiredQueueIDs(_ context.Context, _ time.Time) ([]string, error) {
+func (f *fakeCleaner) ExpiredQueueIDs(ctx context.Context, _ time.Time) ([]string, error) {
+	if f.listDelay > 0 {
+		select {
+		case <-time.After(f.listDelay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
@@ -104,6 +114,55 @@ func TestTick_ListErrorReturnsZero(t *testing.T) {
 	r := &cleanup.Runner{Cleaner: c}
 	if got := r.Tick(context.Background()); got != 0 {
 		t.Errorf("deleted on list error: got %d, want 0", got)
+	}
+}
+
+// TestRun_ExitsOnContextCancel is the regression guard for the shutdown
+// race between cleanup goroutine and DB close: when its context is
+// cancelled the Run loop must return promptly even if a Tick is
+// in-flight, otherwise main()'s wait-then-close sequence would risk
+// closing the store under an active query.
+func TestRun_ExitsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	c := &fakeCleaner{
+		expired:   []string{"q1"},
+		listDelay: 200 * time.Millisecond,
+	}
+	r := &cleanup.Runner{Cleaner: c, Interval: 10 * time.Millisecond}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.Run(ctx)
+	}()
+
+	// Give Run a tick to enter ExpiredQueueIDs.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return within 2s of context cancel")
+	}
+}
+
+// TestRun_ZeroInterval is a smoke test for the documented contract that
+// Runner.Run with Interval <= 0 returns immediately rather than spinning.
+func TestRun_ZeroInterval(t *testing.T) {
+	t.Parallel()
+	r := &cleanup.Runner{Cleaner: &fakeCleaner{}}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.Run(context.Background())
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run with zero interval did not return")
 	}
 }
 

--- a/server/internal/storage/cleanup/cleanup_test.go
+++ b/server/internal/storage/cleanup/cleanup_test.go
@@ -123,8 +123,10 @@ func TestTick_AgainstRealSQLiteStore(t *testing.T) {
 	defer func() { _ = st.Close() }()
 
 	ctx := context.Background()
+	x := make([]byte, queue.X25519PubKeyBytes)
+	x[0] = 1
 	keys := queue.OwnerKeys{
-		X25519Pub:  make([]byte, queue.X25519PubKeyBytes),
+		X25519Pub:  x,
 		Ed25519Pub: make([]byte, queue.Ed25519PubKeyBytes),
 	}
 	q, err := st.CreateQueue(ctx, keys)

--- a/server/internal/storage/cleanup/cleanup_test.go
+++ b/server/internal/storage/cleanup/cleanup_test.go
@@ -145,8 +145,9 @@ func TestTick_AgainstRealSQLiteStore(t *testing.T) {
 	if _, err := st.GetQueue(ctx, q.ID); !errors.Is(err, queue.ErrQueueNotFound) {
 		t.Errorf("queue still present after cleanup: %v", err)
 	}
-	// File on disk should be gone.
-	path := filepath.Join(dir, q.ID+".db")
+	// File on disk should be gone. Filenames are HMAC(seed, queueID),
+	// not the raw queue id.
+	path := filepath.Join(dir, seed.QueueFilename(q.ID)+".db")
 	if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
 		t.Errorf("queue db file still exists after cleanup: %v", statErr)
 	}

--- a/server/internal/storage/cleanup/main_test.go
+++ b/server/internal/storage/cleanup/main_test.go
@@ -1,0 +1,17 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package cleanup_test
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain wraps the cleanup tests in goleak so a Run loop that
+// fails to exit on context cancel fails the suite.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/server/internal/storage/memory/memory.go
+++ b/server/internal/storage/memory/memory.go
@@ -4,18 +4,30 @@
 
 // Package memory is an in-memory implementation of storage.Storage.
 //
-// State is lost when the process restarts; intended for tests and short-lived
-// development instances. A persistent encrypted backend can be added behind
-// the same interface without touching API code.
+// State is lost when the process restarts and the data set is bounded
+// only by the constants below; this backend is intended for tests and
+// short-lived development instances, NOT production. A persistent
+// encrypted backend (storage/sqlite) lives behind the same interface
+// for real deployments.
 package memory
 
 import (
 	"context"
-	"sort"
 	"sync"
 	"time"
 
 	"github.com/WissCore/moldchat/server/internal/queue"
+)
+
+// Hard limits to keep the in-memory store from being a DoS surface when
+// it is accidentally left enabled. The caps are deliberately generous so
+// realistic test workloads pass without retuning, and small enough that
+// a misconfigured production deployment cannot grow without bound. When
+// either cap is hit the backend returns queue.ErrServiceCapacity, which
+// the API layer maps to 503 Service Unavailable.
+const (
+	MaxQueues           = 4096
+	MaxMessagesPerQueue = 4096
 )
 
 // Storage holds all queues and messages in process memory.
@@ -52,6 +64,10 @@ func (s *Storage) CreateQueue(_ context.Context, keys queue.OwnerKeys) (*queue.Q
 		LastAccess:      now,
 	}
 	s.mu.Lock()
+	if len(s.queues) >= MaxQueues {
+		s.mu.Unlock()
+		return nil, queue.ErrServiceCapacity
+	}
 	s.queues[id] = q
 	s.mu.Unlock()
 	return cloneQueue(q), nil
@@ -85,6 +101,9 @@ func (s *Storage) PutMessage(_ context.Context, queueID string, blob []byte) (*q
 	if !ok {
 		return nil, queue.ErrQueueNotFound
 	}
+	if len(s.messages[queueID]) >= MaxMessagesPerQueue {
+		return nil, queue.ErrServiceCapacity
+	}
 	id, err := queue.NewMessageID()
 	if err != nil {
 		return nil, err
@@ -113,8 +132,9 @@ func (s *Storage) ListMessages(_ context.Context, queueID string, limit int) ([]
 	if !ok {
 		return nil, false, queue.ErrQueueNotFound
 	}
+	// Messages are appended in arrival order; ReceivedAt is monotonic
+	// non-decreasing (driven by time.Now), so the slice is already sorted.
 	src := s.messages[queueID]
-	sort.SliceStable(src, func(i, j int) bool { return src[i].ReceivedAt.Before(src[j].ReceivedAt) })
 
 	hasMore := false
 	if len(src) > limit {

--- a/server/internal/storage/memory/memory_test.go
+++ b/server/internal/storage/memory/memory_test.go
@@ -98,6 +98,30 @@ func TestPutMessage_RejectsTooLarge(t *testing.T) {
 	}
 }
 
+func TestPutMessage_BoundaryBlobSizes(t *testing.T) {
+	t.Parallel()
+
+	s := memory.New()
+	ctx := context.Background()
+	q, err := s.CreateQueue(ctx, validKeys())
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	// One byte under the limit must succeed.
+	if _, err := s.PutMessage(ctx, q.ID, make([]byte, queue.MaxBlobSize-1)); err != nil {
+		t.Errorf("MaxBlobSize-1: %v", err)
+	}
+	// Exactly at the limit must succeed.
+	if _, err := s.PutMessage(ctx, q.ID, make([]byte, queue.MaxBlobSize)); err != nil {
+		t.Errorf("MaxBlobSize: %v", err)
+	}
+	// One byte over must be rejected.
+	if _, err := s.PutMessage(ctx, q.ID, make([]byte, queue.MaxBlobSize+1)); !errors.Is(err, queue.ErrBlobTooLarge) {
+		t.Errorf("MaxBlobSize+1: got %v, want ErrBlobTooLarge", err)
+	}
+}
+
 func TestPutMessage_QueueNotFound(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/storage/memory/memory_test.go
+++ b/server/internal/storage/memory/memory_test.go
@@ -15,8 +15,10 @@ import (
 )
 
 func validKeys() queue.OwnerKeys {
+	x := make([]byte, queue.X25519PubKeyBytes)
+	x[0] = 1
 	return queue.OwnerKeys{
-		X25519Pub:  make([]byte, queue.X25519PubKeyBytes),
+		X25519Pub:  x,
 		Ed25519Pub: make([]byte, queue.Ed25519PubKeyBytes),
 	}
 }
@@ -26,12 +28,15 @@ func TestCreateQueue_RejectsInvalidKeys(t *testing.T) {
 
 	s := memory.New()
 
+	nonZeroX := make([]byte, queue.X25519PubKeyBytes)
+	nonZeroX[0] = 1
+
 	bad := queue.OwnerKeys{X25519Pub: make([]byte, 31), Ed25519Pub: make([]byte, 32)}
 	if _, err := s.CreateQueue(context.Background(), bad); !errors.Is(err, queue.ErrInvalidX25519Key) {
 		t.Errorf("31-byte X25519: got %v, want ErrInvalidX25519Key", err)
 	}
 
-	bad = queue.OwnerKeys{X25519Pub: make([]byte, 32), Ed25519Pub: make([]byte, 31)}
+	bad = queue.OwnerKeys{X25519Pub: nonZeroX, Ed25519Pub: make([]byte, 31)}
 	if _, err := s.CreateQueue(context.Background(), bad); !errors.Is(err, queue.ErrInvalidEd25519Key) {
 		t.Errorf("31-byte Ed25519: got %v, want ErrInvalidEd25519Key", err)
 	}

--- a/server/internal/storage/sqlite/export_test.go
+++ b/server/internal/storage/sqlite/export_test.go
@@ -1,0 +1,14 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sqlite
+
+// ParseSeedForTest exposes the unexported parseSeed function so the
+// keys fuzz tests can hammer the parser directly. Going through
+// LoadMasterSeed would force every fuzz iteration through t.Setenv,
+// which itself rejects byte sequences (null bytes, "=" characters)
+// that are otherwise interesting inputs to the parser.
+func ParseSeedForTest(raw string) (MasterSeed, error) {
+	return parseSeed(raw)
+}

--- a/server/internal/storage/sqlite/integration_test.go
+++ b/server/internal/storage/sqlite/integration_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//go:build integration
+
+package sqlite_test
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/WissCore/moldchat/server/internal/queue"
+	"github.com/WissCore/moldchat/server/internal/storage/cleanup"
+	"github.com/WissCore/moldchat/server/internal/storage/sqlite"
+)
+
+// TestIntegration_FullLifecycle exercises the whole storage stack end
+// to end: real SQLCipher store, real cleanup runner ticking in the
+// background, real durability across a Close/Reopen cycle, real
+// crypto-shred via TTL eviction. Build-tagged so the regular unit
+// suite stays fast; run with `go test -tags integration ./...`.
+func TestIntegration_FullLifecycle(t *testing.T) {
+	t.Parallel()
+
+	var seed sqlite.MasterSeed
+	if _, err := rand.Read(seed[:]); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	dir := t.TempDir()
+
+	st, err := sqlite.New(seed, dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Phase 1: queue lifecycle.
+	keys := queue.OwnerKeys{
+		X25519Pub:  func() []byte { b := make([]byte, queue.X25519PubKeyBytes); b[0] = 1; return b }(),
+		Ed25519Pub: make([]byte, queue.Ed25519PubKeyBytes),
+	}
+	q, err := st.CreateQueue(ctx, keys)
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+	if _, err := st.PutMessage(ctx, q.ID, []byte("hello")); err != nil {
+		t.Fatalf("PutMessage: %v", err)
+	}
+
+	// Phase 2: durability across restart.
+	if err := st.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	st2, err := sqlite.New(seed, dir)
+	if err != nil {
+		t.Fatalf("re-New: %v", err)
+	}
+	msgs, _, err := st2.ListMessages(ctx, q.ID, 10)
+	if err != nil {
+		t.Fatalf("ListMessages after restart: %v", err)
+	}
+	if len(msgs) != 1 || string(msgs[0].Blob) != "hello" {
+		t.Errorf("durability: got %+v", msgs)
+	}
+
+	// Phase 3: cleanup runner with a frozen far-future clock evicts
+	// the queue, which triggers wal_checkpoint(FULL) and removes the
+	// underlying file.
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+	r := &cleanup.Runner{
+		Cleaner:  st2,
+		Interval: 10 * time.Millisecond,
+		Logger:   logger,
+		Now:      func() time.Time { return time.Now().Add(48 * time.Hour) },
+	}
+	runCtx, runCancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.Run(runCtx)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := st2.GetQueue(ctx, q.ID); errors.Is(err, queue.ErrQueueNotFound) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	runCancel()
+	<-done
+
+	if _, err := st2.GetQueue(ctx, q.ID); !errors.Is(err, queue.ErrQueueNotFound) {
+		t.Errorf("queue not evicted by cleanup: %v", err)
+	}
+
+	if err := st2.Close(); err != nil {
+		t.Errorf("final Close: %v", err)
+	}
+}
+
+// testWriter adapts *testing.T to io.Writer so slog logs land in the
+// test output stream when a phase fails.
+type testWriter struct{ t *testing.T }
+
+func (w testWriter) Write(p []byte) (int, error) {
+	w.t.Helper()
+	w.t.Log(string(p))
+	return len(p), nil
+}

--- a/server/internal/storage/sqlite/keys.go
+++ b/server/internal/storage/sqlite/keys.go
@@ -4,10 +4,13 @@
 
 // Package sqlite implements storage.Storage on top of a SQLCipher-encrypted
 // SQLite database. Per-queue databases live in their own files; their
-// encryption keys are derived from a single master seed via HKDF.
+// encryption keys are derived from a single master seed plus a per-queue
+// random salt via HKDF, so deleting the master row crypto-shreds the
+// queue even if the file is later recovered from a backup or snapshot.
 package sqlite
 
 import (
+	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -27,6 +30,10 @@ const MasterSeedBytes = 32
 // fetch it from an HSM or KMS rather than from an environment variable.
 type MasterSeed [MasterSeedBytes]byte
 
+// QueueKeySaltBytes is the length of the per-queue salt stored in the
+// master database alongside each queue row.
+const QueueKeySaltBytes = 32
+
 // envVarMasterSeed is the environment variable that supplies the seed.
 const envVarMasterSeed = "MOLDD_MASTER_SEED"
 
@@ -34,6 +41,7 @@ const envVarMasterSeed = "MOLDD_MASTER_SEED"
 var (
 	ErrMasterSeedMissing = errors.New("master seed missing: set " + envVarMasterSeed)
 	ErrMasterSeedInvalid = fmt.Errorf("master seed must be base64-encoded %d bytes", MasterSeedBytes)
+	ErrInvalidQueueSalt  = fmt.Errorf("queue salt must be %d bytes", QueueKeySaltBytes)
 )
 
 // LoadMasterSeed reads the seed from the environment variable.
@@ -65,25 +73,46 @@ func parseSeed(raw string) (MasterSeed, error) {
 const (
 	infoMasterDB = "moldd-master-key-v1"
 	infoQueueDB  = "moldd-queue-key-v1|"
+	infoFilename = "moldd-queue-filename-v1"
 )
 
 // MasterKey returns the SQLCipher hex key (without the 'x' wrapper) for
 // the master metadata database. The error is reserved for any future
 // HKDF-side failure; SHA-256 single-block expansion never fails today.
 func (m MasterSeed) MasterKey() (string, error) {
-	return deriveKey(m[:], []byte(infoMasterDB))
+	return deriveKey(m[:], nil, []byte(infoMasterDB))
 }
 
 // DeriveQueueKey returns the SQLCipher hex key (without the 'x' wrapper)
-// for the per-queue database identified by queueID.
-func (m MasterSeed) DeriveQueueKey(queueID string) (string, error) {
-	return deriveKey(m[:], append([]byte(infoQueueDB), []byte(queueID)...))
+// for the per-queue database identified by queueID and bound to the
+// supplied per-queue salt. Once the salt is overwritten or deleted, the
+// queue's database file becomes unrecoverable even when the master seed
+// is intact — this is the crypto-shred property.
+func (m MasterSeed) DeriveQueueKey(queueID string, salt []byte) (string, error) {
+	if len(salt) != QueueKeySaltBytes {
+		return "", ErrInvalidQueueSalt
+	}
+	info := append([]byte(infoQueueDB), []byte(queueID)...)
+	return deriveKey(m[:], salt, info)
 }
 
-// deriveKey runs HKDF-Expand with SHA-256 over the IKM and returns 32
-// bytes hex-encoded, ready to be embedded in a SQLCipher PRAGMA key.
-func deriveKey(ikm, info []byte) (string, error) {
-	r := hkdf.New(sha256.New, ikm, nil, info)
+// QueueFilename returns the on-disk basename for the queue's database
+// file. The basename is HMAC(seed, queueID) so a directory listing of the
+// data dir does not reveal which queue identifiers exist; mapping a
+// queueID to its file requires the master seed.
+func (m MasterSeed) QueueFilename(queueID string) string {
+	mac := hmac.New(sha256.New, m[:])
+	_, _ = mac.Write([]byte(infoFilename))
+	_, _ = mac.Write([]byte{0})
+	_, _ = mac.Write([]byte(queueID))
+	return hex.EncodeToString(mac.Sum(nil)[:16])
+}
+
+// deriveKey runs HKDF-Extract+Expand with SHA-256 over the IKM and salt
+// and returns 32 bytes hex-encoded, ready to be embedded in a SQLCipher
+// PRAGMA key.
+func deriveKey(ikm, salt, info []byte) (string, error) {
+	r := hkdf.New(sha256.New, ikm, salt, info)
 	out := make([]byte, MasterSeedBytes)
 	if _, err := io.ReadFull(r, out); err != nil {
 		return "", fmt.Errorf("hkdf read: %w", err)

--- a/server/internal/storage/sqlite/keys.go
+++ b/server/internal/storage/sqlite/keys.go
@@ -67,27 +67,26 @@ const (
 	infoQueueDB  = "moldd-queue-key-v1|"
 )
 
-// MasterKey returns the SQLCipher hex key (without 'x' wrapper) for the
-// master metadata database.
-func (m MasterSeed) MasterKey() string {
+// MasterKey returns the SQLCipher hex key (without the 'x' wrapper) for
+// the master metadata database. The error is reserved for any future
+// HKDF-side failure; SHA-256 single-block expansion never fails today.
+func (m MasterSeed) MasterKey() (string, error) {
 	return deriveKey(m[:], []byte(infoMasterDB))
 }
 
-// DeriveQueueKey returns the SQLCipher hex key (without 'x' wrapper) for the
-// per-queue database identified by queueID.
-func (m MasterSeed) DeriveQueueKey(queueID string) string {
+// DeriveQueueKey returns the SQLCipher hex key (without the 'x' wrapper)
+// for the per-queue database identified by queueID.
+func (m MasterSeed) DeriveQueueKey(queueID string) (string, error) {
 	return deriveKey(m[:], append([]byte(infoQueueDB), []byte(queueID)...))
 }
 
-// deriveKey runs HKDF-Expand with SHA-256 over the IKM and returns 32 bytes
-// hex-encoded uppercase, ready to be embedded in a SQLCipher PRAGMA key.
-func deriveKey(ikm, info []byte) string {
+// deriveKey runs HKDF-Expand with SHA-256 over the IKM and returns 32
+// bytes hex-encoded, ready to be embedded in a SQLCipher PRAGMA key.
+func deriveKey(ikm, info []byte) (string, error) {
 	r := hkdf.New(sha256.New, ikm, nil, info)
 	out := make([]byte, MasterSeedBytes)
 	if _, err := io.ReadFull(r, out); err != nil {
-		// HKDF.Read on SHA-256 output cannot fail under reasonable constraints
-		// (we request a single-block expansion); treat any I/O error as fatal.
-		panic(fmt.Errorf("hkdf read: %w", err))
+		return "", fmt.Errorf("hkdf read: %w", err)
 	}
-	return hex.EncodeToString(out)
+	return hex.EncodeToString(out), nil
 }

--- a/server/internal/storage/sqlite/keys_fuzz_test.go
+++ b/server/internal/storage/sqlite/keys_fuzz_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sqlite_test
+
+import (
+	"encoding/base64"
+	"errors"
+	"testing"
+
+	"github.com/WissCore/moldchat/server/internal/storage/sqlite"
+)
+
+// FuzzParseSeed exercises the seed parser against arbitrary
+// base64-shaped inputs. The function must not panic and any error
+// it returns must be one of the documented sentinels — anything
+// else (a wrapped fmt.Errorf, an os.PathError, etc.) would surface
+// to operators as "internal error" instead of the precise
+// "missing/invalid seed" diagnostic main() relies on.
+func FuzzParseSeed(f *testing.F) {
+	seeds := []string{
+		"",
+		"too-short",
+		base64.StdEncoding.EncodeToString(make([]byte, sqlite.MasterSeedBytes)),
+		base64.RawStdEncoding.EncodeToString(make([]byte, sqlite.MasterSeedBytes)),
+		"!!!not-base64!!!",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, raw string) {
+		_, err := sqlite.ParseSeedForTest(raw)
+		if err == nil {
+			return
+		}
+		if !errors.Is(err, sqlite.ErrMasterSeedMissing) &&
+			!errors.Is(err, sqlite.ErrMasterSeedInvalid) {
+			t.Errorf("unexpected error type: %T %v", err, err)
+		}
+	})
+}
+
+// FuzzDeriveQueueKey hammers the per-queue HKDF derivation with
+// arbitrary queue identifiers and salt buffers. The function must:
+// (a) never panic, (b) reject malformed salt (length != 32) only with
+// ErrInvalidQueueSalt, (c) be deterministic — same inputs must yield
+// the same key, otherwise the encrypted DB becomes unrecoverable on
+// the next pool open.
+func FuzzDeriveQueueKey(f *testing.F) {
+	f.Add("queue-1", make([]byte, sqlite.QueueKeySaltBytes))
+	f.Add("", []byte(nil))
+	f.Add("very-long-queue-id-with-unicode-Ω-and-bytes\x00", []byte("short"))
+	f.Fuzz(func(t *testing.T, queueID string, salt []byte) {
+		var seed sqlite.MasterSeed
+		got, err := seed.DeriveQueueKey(queueID, salt)
+		if err != nil && !errors.Is(err, sqlite.ErrInvalidQueueSalt) {
+			t.Errorf("unexpected error: %T %v", err, err)
+			return
+		}
+		if err != nil {
+			return
+		}
+		again, err2 := seed.DeriveQueueKey(queueID, salt)
+		if err2 != nil {
+			t.Errorf("re-derivation failed: %v", err2)
+			return
+		}
+		if got != again {
+			t.Errorf("queue-key derivation not deterministic")
+		}
+	})
+}
+
+// FuzzQueueFilename verifies that arbitrary queue identifiers always
+// yield a deterministic 32-hex-char filename and that the function
+// never panics — it is on the hot path for every storage operation.
+func FuzzQueueFilename(f *testing.F) {
+	f.Add("queue-1")
+	f.Add("")
+	f.Add("\x00\x01\x02")
+	f.Fuzz(func(t *testing.T, queueID string) {
+		var seed sqlite.MasterSeed
+		got := seed.QueueFilename(queueID)
+		if len(got) != 32 {
+			t.Errorf("filename length: got %d, want 32", len(got))
+		}
+		if got != seed.QueueFilename(queueID) {
+			t.Error("filename derivation not deterministic")
+		}
+	})
+}

--- a/server/internal/storage/sqlite/keys_test.go
+++ b/server/internal/storage/sqlite/keys_test.go
@@ -19,8 +19,14 @@ func TestDeriveQueueKey_Deterministic(t *testing.T) {
 	for i := range seed {
 		seed[i] = byte(i)
 	}
-	a := seed.DeriveQueueKey("queue-1")
-	b := seed.DeriveQueueKey("queue-1")
+	a, err := seed.DeriveQueueKey("queue-1")
+	if err != nil {
+		t.Fatalf("DeriveQueueKey: %v", err)
+	}
+	b, err := seed.DeriveQueueKey("queue-1")
+	if err != nil {
+		t.Fatalf("DeriveQueueKey: %v", err)
+	}
 	if a != b {
 		t.Errorf("derive is not deterministic: %s != %s", a, b)
 	}
@@ -33,8 +39,14 @@ func TestDeriveQueueKey_DistinctPerQueue(t *testing.T) {
 	for i := range seed {
 		seed[i] = byte(i)
 	}
-	a := seed.DeriveQueueKey("queue-1")
-	b := seed.DeriveQueueKey("queue-2")
+	a, err := seed.DeriveQueueKey("queue-1")
+	if err != nil {
+		t.Fatalf("DeriveQueueKey: %v", err)
+	}
+	b, err := seed.DeriveQueueKey("queue-2")
+	if err != nil {
+		t.Fatalf("DeriveQueueKey: %v", err)
+	}
 	if a == b {
 		t.Errorf("two queues produced the same key: %s", a)
 	}
@@ -44,9 +56,15 @@ func TestDeriveQueueKey_IsolatedFromMaster(t *testing.T) {
 	t.Parallel()
 
 	var seed sqlite.MasterSeed
-	master := seed.MasterKey()
-	queue := seed.DeriveQueueKey("any-id")
-	if master == queue {
+	master, err := seed.MasterKey()
+	if err != nil {
+		t.Fatalf("MasterKey: %v", err)
+	}
+	queueKey, err := seed.DeriveQueueKey("any-id")
+	if err != nil {
+		t.Fatalf("DeriveQueueKey: %v", err)
+	}
+	if master == queueKey {
 		t.Errorf("master key collides with queue key: %s", master)
 	}
 }
@@ -55,7 +73,10 @@ func TestDeriveKey_Length(t *testing.T) {
 	t.Parallel()
 
 	var seed sqlite.MasterSeed
-	got := seed.DeriveQueueKey("anything")
+	got, err := seed.DeriveQueueKey("anything")
+	if err != nil {
+		t.Fatalf("DeriveQueueKey: %v", err)
+	}
 	if len(got) != 64 {
 		t.Errorf("hex key length: got %d, want 64", len(got))
 	}

--- a/server/internal/storage/sqlite/keys_test.go
+++ b/server/internal/storage/sqlite/keys_test.go
@@ -12,6 +12,14 @@ import (
 	"github.com/WissCore/moldchat/server/internal/storage/sqlite"
 )
 
+func nonZeroSalt() []byte {
+	salt := make([]byte, sqlite.QueueKeySaltBytes)
+	for i := range salt {
+		salt[i] = byte(i + 1)
+	}
+	return salt
+}
+
 func TestDeriveQueueKey_Deterministic(t *testing.T) {
 	t.Parallel()
 
@@ -19,11 +27,12 @@ func TestDeriveQueueKey_Deterministic(t *testing.T) {
 	for i := range seed {
 		seed[i] = byte(i)
 	}
-	a, err := seed.DeriveQueueKey("queue-1")
+	salt := nonZeroSalt()
+	a, err := seed.DeriveQueueKey("queue-1", salt)
 	if err != nil {
 		t.Fatalf("DeriveQueueKey: %v", err)
 	}
-	b, err := seed.DeriveQueueKey("queue-1")
+	b, err := seed.DeriveQueueKey("queue-1", salt)
 	if err != nil {
 		t.Fatalf("DeriveQueueKey: %v", err)
 	}
@@ -39,16 +48,53 @@ func TestDeriveQueueKey_DistinctPerQueue(t *testing.T) {
 	for i := range seed {
 		seed[i] = byte(i)
 	}
-	a, err := seed.DeriveQueueKey("queue-1")
+	salt := nonZeroSalt()
+	a, err := seed.DeriveQueueKey("queue-1", salt)
 	if err != nil {
 		t.Fatalf("DeriveQueueKey: %v", err)
 	}
-	b, err := seed.DeriveQueueKey("queue-2")
+	b, err := seed.DeriveQueueKey("queue-2", salt)
 	if err != nil {
 		t.Fatalf("DeriveQueueKey: %v", err)
 	}
 	if a == b {
 		t.Errorf("two queues produced the same key: %s", a)
+	}
+}
+
+func TestDeriveQueueKey_DistinctPerSalt(t *testing.T) {
+	t.Parallel()
+
+	var seed sqlite.MasterSeed
+	for i := range seed {
+		seed[i] = byte(i)
+	}
+	saltA := make([]byte, sqlite.QueueKeySaltBytes)
+	saltB := make([]byte, sqlite.QueueKeySaltBytes)
+	saltA[0] = 1
+	saltB[0] = 2
+	a, err := seed.DeriveQueueKey("queue-1", saltA)
+	if err != nil {
+		t.Fatalf("DeriveQueueKey: %v", err)
+	}
+	b, err := seed.DeriveQueueKey("queue-1", saltB)
+	if err != nil {
+		t.Fatalf("DeriveQueueKey: %v", err)
+	}
+	if a == b {
+		t.Errorf("salt change did not change derived key — crypto-shred is broken: %s", a)
+	}
+}
+
+func TestDeriveQueueKey_RejectsInvalidSalt(t *testing.T) {
+	t.Parallel()
+
+	var seed sqlite.MasterSeed
+	if _, err := seed.DeriveQueueKey("q", make([]byte, sqlite.QueueKeySaltBytes-1)); !errors.Is(err, sqlite.ErrInvalidQueueSalt) {
+		t.Errorf("short salt: got %v, want ErrInvalidQueueSalt", err)
+	}
+	if _, err := seed.DeriveQueueKey("q", nil); !errors.Is(err, sqlite.ErrInvalidQueueSalt) {
+		t.Errorf("nil salt: got %v, want ErrInvalidQueueSalt", err)
 	}
 }
 
@@ -60,7 +106,7 @@ func TestDeriveQueueKey_IsolatedFromMaster(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MasterKey: %v", err)
 	}
-	queueKey, err := seed.DeriveQueueKey("any-id")
+	queueKey, err := seed.DeriveQueueKey("any-id", nonZeroSalt())
 	if err != nil {
 		t.Fatalf("DeriveQueueKey: %v", err)
 	}
@@ -73,12 +119,40 @@ func TestDeriveKey_Length(t *testing.T) {
 	t.Parallel()
 
 	var seed sqlite.MasterSeed
-	got, err := seed.DeriveQueueKey("anything")
+	got, err := seed.DeriveQueueKey("anything", nonZeroSalt())
 	if err != nil {
 		t.Fatalf("DeriveQueueKey: %v", err)
 	}
 	if len(got) != 64 {
 		t.Errorf("hex key length: got %d, want 64", len(got))
+	}
+}
+
+func TestQueueFilename_HidesQueueID(t *testing.T) {
+	t.Parallel()
+
+	var seed sqlite.MasterSeed
+	for i := range seed {
+		seed[i] = byte(i)
+	}
+	queueID := "VERYLONGUNIQUEQUEUEIDENTIFIERXYZ"
+	filename := seed.QueueFilename(queueID)
+	if filename == queueID {
+		t.Errorf("filename equals queue id: %q", filename)
+	}
+	if len(filename) != 32 {
+		t.Errorf("filename length: got %d, want 32 hex chars", len(filename))
+	}
+	// Determinism: same input → same output, otherwise lookups fail.
+	if filename != seed.QueueFilename(queueID) {
+		t.Error("filename derivation not deterministic")
+	}
+	// Different seeds produce different filenames so an attacker who
+	// learns the seed of one deployment cannot enumerate another.
+	var other sqlite.MasterSeed
+	other[0] = 1
+	if other.QueueFilename(queueID) == filename {
+		t.Error("filename does not depend on seed")
 	}
 }
 

--- a/server/internal/storage/sqlite/pool.go
+++ b/server/internal/storage/sqlite/pool.go
@@ -1,0 +1,214 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sqlite
+
+import (
+	"container/list"
+	"database/sql"
+	"errors"
+	"sync"
+)
+
+// queueDBCapacity bounds the number of per-queue *sql.DB handles the
+// pool keeps open at once. Per-queue files are not WAL so they use one
+// FD each; the master DB plus its WAL/-shm consume three more, and
+// http listeners, stdio, and runtime housekeeping take roughly fifty.
+// At cap=256 the worst case fits well inside the typical container
+// ulimit of 1024, leaving headroom for sudden bursts of FD-hungry
+// operations (TLS handshakes via the Xray frontend, log rotation).
+// Operators running with a higher ulimit can tune via build-time
+// override if needed.
+const queueDBCapacity = 256
+
+// errPoolClosed is returned from acquire after Close has been called.
+var errPoolClosed = errors.New("queue db pool closed")
+
+// queueDBPool is an LRU cache of opened per-queue databases.
+//
+// The pool exists to amortise the cost of opening (and re-running schema
+// init on) each per-queue file across the many requests that target the
+// same queue. acquire returns the cached handle plus a release function;
+// callers must call release exactly once when they are done with the
+// handle. Eviction defers the actual db.Close until the last in-flight
+// caller has released its reference, so a hot eviction never closes a
+// connection out from under an active query.
+type queueDBPool struct {
+	mu        sync.Mutex
+	capacity  int
+	order     *list.List // front = MRU, back = LRU
+	index     map[string]*list.Element
+	closed    bool
+	hits      uint64
+	misses    uint64
+	evictions uint64
+}
+
+// PoolStats is a point-in-time snapshot of the pool's counters,
+// suitable for exporting to the L8 aggregate-counter pipeline.
+type PoolStats struct {
+	Size      int
+	Hits      uint64
+	Misses    uint64
+	Evictions uint64
+}
+
+// Stats returns a copy of the current pool counters.
+func (p *queueDBPool) Stats() PoolStats {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return PoolStats{
+		Size:      len(p.index),
+		Hits:      p.hits,
+		Misses:    p.misses,
+		Evictions: p.evictions,
+	}
+}
+
+type queueDBEntry struct {
+	queueID string
+	db      *sql.DB
+	refs    int
+	evicted bool
+	// onClose runs after the entry's *sql.DB has been closed and is
+	// the hook callers use to wipe per-entry secrets (e.g., the
+	// per-queue salt buffer captured by the deriveKey closure).
+	// Invoked at most once.
+	onClose func()
+}
+
+func newQueueDBPool(capacity int) *queueDBPool {
+	return &queueDBPool{
+		capacity: capacity,
+		order:    list.New(),
+		index:    make(map[string]*list.Element),
+	}
+}
+
+// acquire returns the cached *sql.DB for queueID, opening a fresh one
+// via opener if the queue is not yet cached. The returned release
+// callback decrements the refcount; closing the pool, evicting under
+// pressure, or both will defer the underlying Close until refs == 0.
+// onClose is invoked once after the underlying *sql.DB is closed and
+// is intended for wiping per-entry secrets such as the per-queue salt.
+func (p *queueDBPool) acquire(queueID string, opener func() (*sql.DB, error), onClose func()) (*sql.DB, func(), error) {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil, nil, errPoolClosed
+	}
+	if elem, ok := p.index[queueID]; ok {
+		entry := elem.Value.(*queueDBEntry)
+		entry.refs++
+		p.order.MoveToFront(elem)
+		p.hits++
+		p.mu.Unlock()
+		return entry.db, p.releaseFunc(entry), nil
+	}
+	p.misses++
+	p.mu.Unlock()
+
+	// Open outside the lock — opening a SQLCipher DB takes milliseconds
+	// and we do not want to serialise concurrent first-touches.
+	db, err := opener()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		_ = db.Close()
+		if onClose != nil {
+			onClose()
+		}
+		return nil, nil, errPoolClosed
+	}
+	// Another caller may have populated the entry while we were opening.
+	if elem, ok := p.index[queueID]; ok {
+		_ = db.Close()
+		if onClose != nil {
+			onClose()
+		}
+		entry := elem.Value.(*queueDBEntry)
+		entry.refs++
+		p.order.MoveToFront(elem)
+		p.hits++
+		p.mu.Unlock()
+		return entry.db, p.releaseFunc(entry), nil
+	}
+	if len(p.index) >= p.capacity {
+		p.evictOldestLocked()
+	}
+	entry := &queueDBEntry{queueID: queueID, db: db, refs: 1, onClose: onClose}
+	elem := p.order.PushFront(entry)
+	p.index[queueID] = elem
+	p.mu.Unlock()
+	return db, p.releaseFunc(entry), nil
+}
+
+// drop removes a specific queue's cached entry. Used by DeleteQueue so
+// the file can be unlinked without leaving a pinned handle behind.
+func (p *queueDBPool) drop(queueID string) {
+	p.mu.Lock()
+	elem, ok := p.index[queueID]
+	if !ok {
+		p.mu.Unlock()
+		return
+	}
+	entry := elem.Value.(*queueDBEntry)
+	delete(p.index, queueID)
+	p.order.Remove(elem)
+	entry.evicted = true
+	p.maybeCloseLocked(entry)
+	p.mu.Unlock()
+}
+
+// Close evicts every cached db and closes its handle once the last
+// in-flight caller has released. Subsequent acquire calls return
+// errPoolClosed.
+func (p *queueDBPool) Close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closed = true
+	for elem := p.order.Front(); elem != nil; elem = elem.Next() {
+		entry := elem.Value.(*queueDBEntry)
+		entry.evicted = true
+		p.maybeCloseLocked(entry)
+	}
+	p.order.Init()
+	p.index = make(map[string]*list.Element)
+}
+
+func (p *queueDBPool) releaseFunc(entry *queueDBEntry) func() {
+	return func() {
+		p.mu.Lock()
+		entry.refs--
+		p.maybeCloseLocked(entry)
+		p.mu.Unlock()
+	}
+}
+
+func (p *queueDBPool) evictOldestLocked() {
+	elem := p.order.Back()
+	if elem == nil {
+		return
+	}
+	entry := elem.Value.(*queueDBEntry)
+	delete(p.index, entry.queueID)
+	p.order.Remove(elem)
+	entry.evicted = true
+	p.evictions++
+	p.maybeCloseLocked(entry)
+}
+
+func (p *queueDBPool) maybeCloseLocked(entry *queueDBEntry) {
+	if entry.evicted && entry.refs == 0 {
+		_ = entry.db.Close()
+		if entry.onClose != nil {
+			entry.onClose()
+			entry.onClose = nil
+		}
+	}
+}

--- a/server/internal/storage/sqlite/pool_test.go
+++ b/server/internal/storage/sqlite/pool_test.go
@@ -1,0 +1,403 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sqlite
+
+import (
+	"crypto/rand"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// newOpener returns an opener that produces a fresh *sql.DB plus a
+// counter the test can inspect to verify how many times the opener
+// actually ran.
+func newOpener(t *testing.T, dir, queueID string) (func() (*sql.DB, error), *atomic.Int64) {
+	t.Helper()
+	calls := &atomic.Int64{}
+	var seed MasterSeed
+	if _, err := rand.Read(seed[:]); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	salt := make([]byte, QueueKeySaltBytes)
+	for i := range salt {
+		salt[i] = byte(i + 1)
+	}
+	return func() (*sql.DB, error) {
+		calls.Add(1)
+		return openEncryptedDB(
+			filepath.Join(dir, queueID+queueFilenameSuffix),
+			func() (string, error) { return seed.DeriveQueueKey(queueID, salt) },
+			false,
+			1,
+		)
+	}, calls
+}
+
+func TestPool_AcquireReleaseSingleQueue(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	pool := newQueueDBPool(4)
+	t.Cleanup(pool.Close)
+
+	opener, calls := newOpener(t, dir, "Q1")
+	db, release, err := pool.acquire("Q1", opener, nil)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if db == nil {
+		t.Fatal("db is nil")
+	}
+	release()
+
+	// Second acquire should be a cache hit.
+	db2, release2, err := pool.acquire("Q1", opener, nil)
+	if err != nil {
+		t.Fatalf("acquire 2: %v", err)
+	}
+	if db != db2 {
+		t.Errorf("expected same db handle on cache hit")
+	}
+	release2()
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("opener calls: got %d, want 1", got)
+	}
+	if stats := pool.Stats(); stats.Hits != 1 || stats.Misses != 1 {
+		t.Errorf("stats: %+v", stats)
+	}
+}
+
+func TestPool_EvictionRespectsRefcount(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	pool := newQueueDBPool(2)
+	t.Cleanup(pool.Close)
+
+	opener1, _ := newOpener(t, dir, "Q1")
+	opener2, _ := newOpener(t, dir, "Q2")
+	opener3, _ := newOpener(t, dir, "Q3")
+
+	closed1 := &atomic.Bool{}
+	db1, rel1, err := pool.acquire("Q1", opener1, func() { closed1.Store(true) })
+	if err != nil {
+		t.Fatalf("acquire Q1: %v", err)
+	}
+	defer rel1()
+	_, rel2, err := pool.acquire("Q2", opener2, nil)
+	if err != nil {
+		t.Fatalf("acquire Q2: %v", err)
+	}
+	rel2()
+
+	// Acquiring Q3 evicts Q2 (LRU); Q1 stays because it was used most
+	// recently and has an outstanding ref.
+	_, rel3, err := pool.acquire("Q3", opener3, nil)
+	if err != nil {
+		t.Fatalf("acquire Q3: %v", err)
+	}
+	rel3()
+
+	// Now access Q3 again, then Q2 — Q2 was evicted, so it must
+	// re-open. Use yet another opener to verify miss path.
+	_, _, err = pool.acquire("Q2", opener2, nil)
+	if err != nil {
+		t.Fatalf("acquire Q2 again: %v", err)
+	}
+
+	// Q1 was held throughout, so its handle must still be alive.
+	if closed1.Load() {
+		t.Error("Q1 was closed while still referenced")
+	}
+	if db1 == nil {
+		t.Error("Q1 handle nil")
+	}
+}
+
+func TestPool_OnCloseRunsAfterEvictionAndLastRelease(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	pool := newQueueDBPool(1) // capacity 1 forces immediate eviction
+	t.Cleanup(pool.Close)
+
+	opener1, _ := newOpener(t, dir, "Q1")
+	opener2, _ := newOpener(t, dir, "Q2")
+
+	closed := &atomic.Bool{}
+	_, rel1, err := pool.acquire("Q1", opener1, func() { closed.Store(true) })
+	if err != nil {
+		t.Fatalf("acquire Q1: %v", err)
+	}
+
+	// Acquire Q2 — Q1 is evicted but still has refs. onClose must
+	// not run yet.
+	_, rel2, err := pool.acquire("Q2", opener2, nil)
+	if err != nil {
+		t.Fatalf("acquire Q2: %v", err)
+	}
+	if closed.Load() {
+		t.Fatal("onClose fired while ref still held")
+	}
+
+	rel1()
+	if !closed.Load() {
+		t.Fatal("onClose did not fire after final release of evicted entry")
+	}
+	rel2()
+}
+
+func TestPool_OnCloseRunsAtMostOnce(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	pool := newQueueDBPool(1)
+
+	opener, _ := newOpener(t, dir, "Q1")
+	count := &atomic.Int64{}
+	_, rel, err := pool.acquire("Q1", opener, func() { count.Add(1) })
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	rel()
+	pool.Close()
+	if got := count.Load(); got != 1 {
+		t.Errorf("onClose calls: got %d, want 1", got)
+	}
+}
+
+func TestPool_AcquireAfterCloseFails(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	pool := newQueueDBPool(1)
+	pool.Close()
+
+	opener, _ := newOpener(t, dir, "Q1")
+	_, _, err := pool.acquire("Q1", opener, nil)
+	if !errors.Is(err, errPoolClosed) {
+		t.Errorf("got %v, want errPoolClosed", err)
+	}
+}
+
+// TestPool_ConcurrentStress hammers the pool from many goroutines so the
+// race detector and refcount-vs-eviction logic are exercised together.
+// On top of "no error" it asserts the canonical leak invariant —
+// after Close, every open must be balanced by exactly one close — and
+// the bound that the pool size never exceeds its configured capacity.
+func TestPool_ConcurrentStress(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	const capacity = 8
+	pool := newQueueDBPool(capacity)
+
+	const queues = 32
+	const goroutines = 64
+	const perGoroutine = 50
+
+	openers := make([]func() (*sql.DB, error), queues)
+	openCounts := make([]*atomic.Int64, queues)
+	closeCounts := make([]*atomic.Int64, queues)
+	for i := range openers {
+		baseOpener, _ := newOpener(t, dir, idFor(i))
+		openCounts[i] = &atomic.Int64{}
+		closeCounts[i] = &atomic.Int64{}
+		idx := i
+		openers[i] = func() (*sql.DB, error) {
+			// Count only successful opens — every successful open
+			// must be balanced by exactly one onClose, regardless
+			// of whether the entry is stored, raced out by another
+			// goroutine, or rejected because the pool was closed
+			// in the gap between open and registration.
+			db, err := baseOpener()
+			if err != nil {
+				return nil, err
+			}
+			openCounts[idx].Add(1)
+			return db, nil
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(seed int) {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				idx := (seed*7 + j) % queues
+				closeIdx := idx
+				_, rel, err := pool.acquire(
+					idFor(idx),
+					openers[idx],
+					func() { closeCounts[closeIdx].Add(1) },
+				)
+				if err != nil {
+					t.Errorf("acquire: %v", err)
+					return
+				}
+				if size := pool.Stats().Size; size > capacity {
+					t.Errorf("pool size %d exceeded capacity %d", size, capacity)
+				}
+				rel()
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	// Final invariant: pool.Close() must drain every cached handle
+	// and trigger every onClose hook for which a corresponding open
+	// happened. opens == closes per-key with no exceptions.
+	pool.Close()
+	for i := range openers {
+		opens := openCounts[i].Load()
+		closes := closeCounts[i].Load()
+		if opens != closes {
+			t.Errorf("queue %d: opens=%d closes=%d (must be equal after pool.Close)", i, opens, closes)
+		}
+	}
+}
+
+func idFor(i int) string {
+	const alpha = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+	return string(alpha[i%len(alpha)]) + string(alpha[(i*3)%len(alpha)])
+}
+
+// TestPool_ConcurrentAcquireSameKey covers the race where two
+// goroutines miss the cache for the same key at the same time. The
+// pool's design is to let both call opener (concurrently, off-lock)
+// and then resolve under lock: one wins, one closes its db and gets
+// the winner's handle. The visible contract is that both callers see
+// the same *sql.DB and the loser's onClose fires immediately, not
+// when the entry is later evicted.
+func TestPool_ConcurrentAcquireSameKey(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	pool := newQueueDBPool(4)
+	t.Cleanup(pool.Close)
+
+	opener, openCalls := newOpener(t, dir, "Q1")
+	loserClosed := &atomic.Int64{}
+
+	start := make(chan struct{})
+	type result struct {
+		db  *sql.DB
+		rel func()
+	}
+	results := make(chan result, 2)
+
+	for g := 0; g < 2; g++ {
+		go func() {
+			<-start
+			db, rel, err := pool.acquire("Q1", opener, func() { loserClosed.Add(1) })
+			if err != nil {
+				t.Errorf("acquire: %v", err)
+				results <- result{}
+				return
+			}
+			results <- result{db, rel}
+		}()
+	}
+	close(start)
+	r1 := <-results
+	r2 := <-results
+	if r1.db != r2.db {
+		t.Errorf("concurrent acquires returned different *sql.DB handles")
+	}
+	r1.rel()
+	r2.rel()
+
+	// At most one open call survives in the pool, so at least one of
+	// the two onClose hooks fires immediately on the loser's branch.
+	// The remaining one fires later, on pool.Close (registered above).
+	if openCalls.Load() < 1 || openCalls.Load() > 2 {
+		t.Errorf("opener calls: got %d, want 1 or 2", openCalls.Load())
+	}
+	if loserClosed.Load() < 1 {
+		// The race is allowed to resolve such that one open never
+		// happened (one goroutine grabbed the freshly-stored entry
+		// before the other ran its opener). In that case loserClosed
+		// stays 0 and the single onClose fires on pool.Close.
+		t.Logf("no loser branch hit (race resolved on cache hit) — acceptable")
+	}
+}
+
+// TestPool_ResurrectionAfterEviction is the regression guard against
+// "dead" entries staying reachable. After a full eviction cycle,
+// re-acquiring the same key MUST trigger a fresh opener call rather
+// than reuse the closed handle.
+func TestPool_ResurrectionAfterEviction(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	pool := newQueueDBPool(1) // capacity 1 forces eviction on next acquire
+	t.Cleanup(pool.Close)
+
+	opener1, calls1 := newOpener(t, dir, "Q1")
+	opener2, _ := newOpener(t, dir, "Q2")
+
+	_, rel1, err := pool.acquire("Q1", opener1, nil)
+	if err != nil {
+		t.Fatalf("acquire Q1: %v", err)
+	}
+	rel1()
+	// Q2 evicts Q1 (Q1 was at capacity, refs=0 so it closes immediately).
+	_, rel2, err := pool.acquire("Q2", opener2, nil)
+	if err != nil {
+		t.Fatalf("acquire Q2: %v", err)
+	}
+	rel2()
+
+	// Re-acquire Q1: must call opener again (the previous handle is
+	// closed and removed from the index).
+	_, rel3, err := pool.acquire("Q1", opener1, nil)
+	if err != nil {
+		t.Fatalf("acquire Q1 again: %v", err)
+	}
+	rel3()
+	if got := calls1.Load(); got != 2 {
+		t.Errorf("opener1 calls: got %d, want 2 (initial + post-eviction)", got)
+	}
+}
+
+// BenchmarkPool_AcquireRelease measures the steady-state hot path —
+// repeated acquire/release on the same already-cached queue. This is
+// the single most common operation in production once pool warm-up
+// has finished.
+func BenchmarkPool_AcquireRelease(b *testing.B) {
+	dir := b.TempDir()
+	pool := newQueueDBPool(4)
+	b.Cleanup(pool.Close)
+
+	var seed MasterSeed
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+	salt := make([]byte, QueueKeySaltBytes)
+	for i := range salt {
+		salt[i] = byte(i + 1)
+	}
+	opener := func() (*sql.DB, error) {
+		return openEncryptedDB(
+			filepath.Join(dir, "Q1"+queueFilenameSuffix),
+			func() (string, error) { return seed.DeriveQueueKey("Q1", salt) },
+			false,
+			1,
+		)
+	}
+	// Warm the cache so the benchmark measures the hit path.
+	_, rel, err := pool.acquire("Q1", opener, nil)
+	if err != nil {
+		b.Fatalf("warm-up acquire: %v", err)
+	}
+	rel()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, rel, err := pool.acquire("Q1", opener, nil)
+		if err != nil {
+			b.Fatalf("acquire: %v", err)
+		}
+		rel()
+	}
+}

--- a/server/internal/storage/sqlite/store.go
+++ b/server/internal/storage/sqlite/store.go
@@ -52,7 +52,11 @@ func New(seed MasterSeed, dataDir string) (*Store, error) {
 	if mkdirErr := os.MkdirAll(abs, dataDirPerm); mkdirErr != nil {
 		return nil, fmt.Errorf("create dataDir: %w", mkdirErr)
 	}
-	masterDB, err := openEncryptedDB(filepath.Join(abs, masterFilename), seed.MasterKey())
+	masterKey, err := seed.MasterKey()
+	if err != nil {
+		return nil, fmt.Errorf("derive master key: %w", err)
+	}
+	masterDB, err := openEncryptedDB(filepath.Join(abs, masterFilename), masterKey)
 	if err != nil {
 		return nil, fmt.Errorf("open master.db: %w", err)
 	}
@@ -113,7 +117,11 @@ func (s *Store) queuePath(queueID string) string {
 // openQueue opens (and initialises if needed) the per-queue database.
 // The returned handle must be closed by the caller.
 func (s *Store) openQueue(queueID string) (*sql.DB, error) {
-	db, err := openEncryptedDB(s.queuePath(queueID), s.seed.DeriveQueueKey(queueID))
+	queueKey, err := s.seed.DeriveQueueKey(queueID)
+	if err != nil {
+		return nil, fmt.Errorf("derive queue key: %w", err)
+	}
+	db, err := openEncryptedDB(s.queuePath(queueID), queueKey)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/storage/sqlite/store.go
+++ b/server/internal/storage/sqlite/store.go
@@ -6,9 +6,12 @@ package sqlite
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -16,30 +19,139 @@ import (
 
 	"github.com/WissCore/moldchat/server/internal/queue"
 
-	// Registers the "sqlite3" driver with SQLCipher 4.x support.
-	_ "github.com/mutecomm/go-sqlcipher/v4"
+	sqlcipher "github.com/mutecomm/go-sqlcipher/v4"
 )
 
 const (
-	driverName          = "sqlite3"
 	masterFilename      = "master.db"
 	queueFilenameSuffix = ".db"
-	cipherPageSize      = 4096
 	dataDirPerm         = 0o700
+
+	// masterMaxOpenConns leaves WAL room for a writer plus several
+	// concurrent readers without crossing the typical container ulimit
+	// once per-queue handles are factored in (each WAL DB is 3 FDs:
+	// main, -wal, -shm).
+	masterMaxOpenConns = 8
+
+	// queueMaxOpenConns stays at 1 because per-queue files are
+	// write-mostly and not WAL — there is no concurrent-read benefit
+	// to spare connections, and one connection keeps SQLite's writer
+	// serialization free of SQLITE_BUSY.
+	queueMaxOpenConns = 1
 )
+
+// cipherDriver is the SQLCipher driver instance used by the cipherConnector.
+// It is package-level rather than re-allocated per connection so the
+// driver's internal initialisation (loadable extensions, etc.) runs once.
+var cipherDriver = &sqlcipher.SQLiteDriver{}
+
+// cipherConnector is a database/sql Connector that opens a SQLCipher
+// connection, applies the cipher key, and configures privacy-relevant
+// PRAGMAs before returning the connection to the pool.
+//
+// The hex key is produced by deriveKey on every Connect call rather
+// than stored on the struct: this minimises the lifetime of the
+// derived 32-byte secret as a Go string. The seed material itself
+// lives one level up as a [32]byte that callers can later wipe, even
+// though the underlying driver still copies the resulting DSN into
+// its own per-connection state — fully eliminating that copy would
+// require a driver-side change.
+//
+// PRAGMA syntax pitfall: SQLCipher accepts `PRAGMA key = x'<hex>'` as
+// a raw key (blob literal) and `PRAGMA key = "x'<hex>'"` as a
+// passphrase that goes through PBKDF2 — the second form silently
+// produces a different key and surfaces as "file is not a database"
+// on subsequent opens. The _pragma_key URL parameter route used here
+// passes the raw blob literal directly via the driver's open hook; do
+// not switch to a string-quoted PRAGMA form without matching the
+// derivation on the other side.
+type cipherConnector struct {
+	dsn       string
+	deriveKey func() (string, error)
+	enableWAL bool
+}
+
+func (c *cipherConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	hexKey, err := c.deriveKey()
+	if err != nil {
+		return nil, err
+	}
+	conn, err := cipherDriver.Open(c.dsn + "?_pragma_key=x'" + hexKey + "'")
+	if err != nil {
+		return nil, err
+	}
+	execer, ok := conn.(driver.ExecerContext)
+	if !ok {
+		_ = conn.Close()
+		return nil, errors.New("sqlite driver does not implement ExecerContext")
+	}
+	// Force the temp store to memory: by default SQLite may spill
+	// query intermediates (sorts, joins, large GROUP BY) to plaintext
+	// temp files in /tmp, defeating the encryption-at-rest guarantee.
+	// PRAGMA temp_store = MEMORY (=2) overrides the build-time default
+	// at runtime. This is best-effort — if the driver was compiled with
+	// SQLITE_TEMP_STORE=0 (always file, runtime override forbidden) the
+	// PRAGMA returns success and the value is silently ignored. The
+	// upstream go-sqlcipher build does not enforce that mode, so the
+	// runtime override holds for our deployment, but operators
+	// rebuilding with custom flags should re-verify.
+	if _, execErr := execer.ExecContext(ctx, "PRAGMA temp_store = MEMORY", nil); execErr != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("set pragma temp_store: %w", execErr)
+	}
+	if c.enableWAL {
+		if _, execErr := execer.ExecContext(ctx, "PRAGMA journal_mode = WAL", nil); execErr != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("set pragma journal_mode: %w", execErr)
+		}
+	}
+	return conn, nil
+}
+
+func (c *cipherConnector) Driver() driver.Driver { return cipherDriver }
 
 // Store is a SQLCipher-backed implementation of storage.Storage.
 //
-// One master database holds queue metadata; each queue's messages live in
-// their own encrypted file. Database keys are derived from a single master
-// seed via HKDF, so seizing the storage directory without the seed yields
-// only opaque ciphertext.
+// One master database holds queue metadata (including the per-queue
+// salt); each queue's messages live in their own encrypted file whose
+// key is derived from the master seed, the queue id, and that salt.
+// Deleting a queue's master row therefore crypto-shreds the queue: the
+// file may persist on disk or in a backup, but without the salt the
+// HKDF derivation cannot be reproduced.
+//
+// Threat model the crypto-shred property covers:
+//
+//   - File-only attacker (backup leak, filesystem snapshot, forensic
+//     image): cannot recover deleted queues because the salt is gone
+//     from the master row, and we PRAGMA wal_checkpoint(FULL) after
+//     every DeleteQueue so nothing meaningful sits in master.db-wal.
+//   - Cold seed leak: leaking only the master seed without any of the
+//     storage files yields no plaintext.
+//
+// Threat model it does NOT cover:
+//
+//   - Live memory dump: master seed and active per-queue salts both
+//     live in the process heap as Go values; an attacker with
+//     /proc/<pid> access on a live process can still recover them.
+//   - Operational metadata: directory shard count, file mtime/size,
+//     and master.db-wal size leak coarse activity signals to anyone
+//     with filesystem read access. Mitigate via encrypted block
+//     storage and `mount -o noatime`; tracked operationally.
+//   - WAL bytes between commit and checkpoint on per-queue files
+//     (per-queue WAL is currently disabled, so this is a no-op today,
+//     but flip the bit and the same caveat applies).
 type Store struct {
 	seed     MasterSeed
 	dataDir  string
 	masterDB *sql.DB
-
-	mu sync.Mutex
+	pool     *queueDBPool
+	// queueLocks serialises operations targeting the same queue.
+	// DeleteQueue takes the write side (exclusive); concurrent
+	// PutMessage / ListMessages / DeleteMessage on the same id share
+	// the read side, so they can proceed in parallel without
+	// contending on each other while still being mutually exclusive
+	// with the destructor.
+	queueLocks sync.Map // map[string]*sync.RWMutex
 }
 
 // New opens (or creates) the master database and initialises its schema.
@@ -52,11 +164,12 @@ func New(seed MasterSeed, dataDir string) (*Store, error) {
 	if mkdirErr := os.MkdirAll(abs, dataDirPerm); mkdirErr != nil {
 		return nil, fmt.Errorf("create dataDir: %w", mkdirErr)
 	}
-	masterKey, err := seed.MasterKey()
-	if err != nil {
-		return nil, fmt.Errorf("derive master key: %w", err)
-	}
-	masterDB, err := openEncryptedDB(filepath.Join(abs, masterFilename), masterKey)
+	masterDB, err := openEncryptedDB(
+		filepath.Join(abs, masterFilename),
+		seed.MasterKey,
+		true,
+		masterMaxOpenConns,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("open master.db: %w", err)
 	}
@@ -64,17 +177,27 @@ func New(seed MasterSeed, dataDir string) (*Store, error) {
 		_ = masterDB.Close()
 		return nil, fmt.Errorf("init master schema: %w", schemaErr)
 	}
-	return &Store{seed: seed, dataDir: abs, masterDB: masterDB}, nil
+	return &Store{
+		seed:     seed,
+		dataDir:  abs,
+		masterDB: masterDB,
+		pool:     newQueueDBPool(queueDBCapacity),
+	}, nil
 }
 
-// Close releases resources held by the store.
-func (s *Store) Close() error { return s.masterDB.Close() }
+// Close releases resources held by the store: it drains the per-queue
+// pool first, then closes the master DB handle.
+func (s *Store) Close() error {
+	s.pool.Close()
+	return s.masterDB.Close()
+}
 
 const masterSchema = `
 CREATE TABLE IF NOT EXISTS queues (
 	id                 TEXT    NOT NULL,
 	owner_x25519_pub   BLOB    NOT NULL,
 	owner_ed25519_pub  BLOB    NOT NULL,
+	key_salt           BLOB    NOT NULL,
 	created_at         INTEGER NOT NULL,
 	expires_at         INTEGER NOT NULL,
 	last_access        INTEGER NOT NULL,
@@ -93,16 +216,30 @@ CREATE TABLE IF NOT EXISTS messages (
 CREATE INDEX IF NOT EXISTS idx_messages_received_at ON messages(received_at);
 `
 
-// openEncryptedDB opens a SQLCipher database at path with the given hex key.
-// The connection pool is capped at 1 to match SQLite's single-writer model.
-func openEncryptedDB(path, hexKey string) (*sql.DB, error) {
-	dsn := fmt.Sprintf("file:%s?_pragma_key=x'%s'&_pragma_cipher_page_size=%d",
-		path, hexKey, cipherPageSize)
-	db, err := sql.Open(driverName, dsn)
-	if err != nil {
-		return nil, err
+// openEncryptedDB opens a SQLCipher database at path. The encryption
+// key is produced lazily by deriveKey on every freshly opened pooled
+// connection, so the derived hex bytes never live on a long-lived
+// struct field. enableWAL is opt-in because per-queue files benefit
+// less from WAL than the hot-path master DB does. maxOpenConns caps
+// the underlying database/sql pool: master uses several to let WAL
+// readers run concurrently; per-queue files stay at 1 because they
+// are write-mostly.
+//
+// Backup note: with WAL enabled, a snapshot tool that copies only the
+// main DB file without the matching -wal/-shm files will see a
+// pre-checkpoint state. Crypto-shred via salt deletion still holds
+// for any data that was committed at snapshot time, but uncommitted
+// pages live in the -wal until checkpointed; backup pipelines must
+// either include all three files or trigger PRAGMA wal_checkpoint
+// before snapshotting.
+func openEncryptedDB(path string, deriveKey func() (string, error), enableWAL bool, maxOpenConns int) (*sql.DB, error) {
+	conn := &cipherConnector{
+		dsn:       "file:" + path,
+		deriveKey: deriveKey,
+		enableWAL: enableWAL,
 	}
-	db.SetMaxOpenConns(1)
+	db := sql.OpenDB(conn)
+	db.SetMaxOpenConns(maxOpenConns)
 	if pingErr := db.Ping(); pingErr != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("ping db: %w", pingErr)
@@ -110,29 +247,72 @@ func openEncryptedDB(path, hexKey string) (*sql.DB, error) {
 	return db, nil
 }
 
+// queuePath returns the absolute filesystem path for the queue's
+// encrypted database. The basename is HMAC(seed, queueID) so a
+// directory listing does not enumerate live queue identifiers, and
+// the file is placed in a two-hex-char shard (up to 256 sub-dirs)
+// so a single readdir at the top level reveals only how many shards
+// exist, not the queue count.
 func (s *Store) queuePath(queueID string) string {
-	return filepath.Join(s.dataDir, queueID+queueFilenameSuffix)
+	name := s.seed.QueueFilename(queueID)
+	return filepath.Join(s.dataDir, name[:2], name[2:]+queueFilenameSuffix)
 }
 
-// openQueue opens (and initialises if needed) the per-queue database.
-// The returned handle must be closed by the caller.
-func (s *Store) openQueue(queueID string) (*sql.DB, error) {
-	queueKey, err := s.seed.DeriveQueueKey(queueID)
-	if err != nil {
-		return nil, fmt.Errorf("derive queue key: %w", err)
-	}
-	db, err := openEncryptedDB(s.queuePath(queueID), queueKey)
-	if err != nil {
-		return nil, err
-	}
-	if _, schemaErr := db.Exec(queueSchema); schemaErr != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("init queue schema: %w", schemaErr)
-	}
-	return db, nil
+// ensureQueueShard creates the per-queue shard sub-directory with the
+// same 0700 permissions as the data dir.
+func (s *Store) ensureQueueShard(queueID string) error {
+	name := s.seed.QueueFilename(queueID)
+	return os.MkdirAll(filepath.Join(s.dataDir, name[:2]), dataDirPerm)
 }
 
-// CreateQueue inserts a new queue row and creates its per-queue database file.
+// useQueueDB acquires the cached *sql.DB for queueID (opening it the
+// first time) and runs fn against it. The acquired handle is released
+// regardless of fn's outcome.
+//
+// The salt is copied into a fresh slice owned by this call's closures
+// — the deriveKey closure re-uses it on every Connect (the SQL pool
+// may open new connections after idle drops), and the onClose hook
+// zeroes it once the entry is evicted from the cache. This caps the
+// in-heap lifetime of the per-queue salt at "while the queue's DB is
+// in cache" rather than "until process death", which materially
+// shortens the window a memory-dump attacker has to recover it.
+func (s *Store) useQueueDB(queueID string, salt []byte, fn func(*sql.DB) error) error {
+	saltCopy := append([]byte(nil), salt...)
+	db, release, err := s.pool.acquire(
+		queueID,
+		func() (*sql.DB, error) {
+			qdb, err := openEncryptedDB(
+				s.queuePath(queueID),
+				func() (string, error) { return s.seed.DeriveQueueKey(queueID, saltCopy) },
+				false,
+				queueMaxOpenConns,
+			)
+			if err != nil {
+				return nil, err
+			}
+			if _, schemaErr := qdb.Exec(queueSchema); schemaErr != nil {
+				_ = qdb.Close()
+				return nil, fmt.Errorf("init queue schema: %w", schemaErr)
+			}
+			return qdb, nil
+		},
+		func() {
+			for i := range saltCopy {
+				saltCopy[i] = 0
+			}
+		},
+	)
+	if err != nil {
+		return err
+	}
+	defer release()
+	return fn(db)
+}
+
+// CreateQueue inserts a new queue row and creates its per-queue database
+// file. A fresh per-queue salt is generated and persisted alongside the
+// metadata; the salt is the load-bearing secret for the crypto-shred
+// property when the queue is later deleted.
 func (s *Store) CreateQueue(ctx context.Context, keys queue.OwnerKeys) (*queue.Queue, error) {
 	if err := queue.ValidateOwnerKeys(keys); err != nil {
 		return nil, err
@@ -141,27 +321,38 @@ func (s *Store) CreateQueue(ctx context.Context, keys queue.OwnerKeys) (*queue.Q
 	if err != nil {
 		return nil, err
 	}
+	salt := make([]byte, QueueKeySaltBytes)
+	if _, err := rand.Read(salt); err != nil {
+		return nil, fmt.Errorf("generate queue salt: %w", err)
+	}
+
+	// Defence in depth against the (cryptographically infeasible) event
+	// of an HMAC-derived filename colliding with an existing file: if
+	// the path already exists, refuse rather than silently overwrite a
+	// foreign queue's data.
+	if err := s.ensureQueueShard(id); err != nil {
+		return nil, fmt.Errorf("create queue shard: %w", err)
+	}
+	if _, statErr := os.Stat(s.queuePath(id)); statErr == nil {
+		return nil, fmt.Errorf("queue file already exists at derived path: %w", os.ErrExist)
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return nil, fmt.Errorf("stat queue path: %w", statErr)
+	}
 
 	now := time.Now().UTC()
 	expires := now.Add(queue.DefaultTTL)
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	if _, execErr := s.masterDB.ExecContext(ctx,
-		`INSERT INTO queues(id, owner_x25519_pub, owner_ed25519_pub, created_at, expires_at, last_access) VALUES (?, ?, ?, ?, ?, ?)`,
-		id, keys.X25519Pub, keys.Ed25519Pub, now.UnixNano(), expires.UnixNano(), now.UnixNano(),
+		`INSERT INTO queues(id, owner_x25519_pub, owner_ed25519_pub, key_salt, created_at, expires_at, last_access) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		id, keys.X25519Pub, keys.Ed25519Pub, salt, now.UnixNano(), expires.UnixNano(), now.UnixNano(),
 	); execErr != nil {
 		return nil, fmt.Errorf("insert queue: %w", execErr)
 	}
 
-	qdb, err := s.openQueue(id)
-	if err != nil {
-		// Roll back the master row so we do not leak a metadata entry without a file.
-		_, _ = s.masterDB.ExecContext(ctx, `DELETE FROM queues WHERE id = ?`, id)
+	if err := s.useQueueDB(id, salt, func(_ *sql.DB) error { return nil }); err != nil {
+		s.rollbackCreate(ctx, id)
 		return nil, fmt.Errorf("init queue db: %w", err)
 	}
-	_ = qdb.Close()
 
 	return &queue.Queue{
 		ID:              id,
@@ -173,31 +364,66 @@ func (s *Store) CreateQueue(ctx context.Context, keys queue.OwnerKeys) (*queue.Q
 	}, nil
 }
 
-// GetQueue returns queue metadata or queue.ErrQueueNotFound.
-func (s *Store) GetQueue(ctx context.Context, id string) (*queue.Queue, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.getQueueLocked(ctx, id)
+// queueLock returns the per-queue RWMutex, creating it on first
+// access. PutMessage / ListMessages / DeleteMessage take RLock so
+// they can run concurrently against the same queue (SQLite's own
+// single-connection writer is the actual serialiser at the SQL
+// layer); DeleteQueue takes the write Lock so it can never
+// interleave with an in-flight per-queue operation.
+func (s *Store) queueLock(queueID string) *sync.RWMutex {
+	if existing, ok := s.queueLocks.Load(queueID); ok {
+		return existing.(*sync.RWMutex)
+	}
+	created := &sync.RWMutex{}
+	actual, _ := s.queueLocks.LoadOrStore(queueID, created)
+	return actual.(*sync.RWMutex)
 }
 
-func (s *Store) getQueueLocked(ctx context.Context, id string) (*queue.Queue, error) {
+// rollbackCreate cleans up after a CreateQueue failure that left the
+// master row in place: it deletes the row, removes the (possibly
+// partially-initialised) queue file, and forces a WAL checkpoint so
+// the salt does not survive in master.db-wal. Failures here are
+// logged at slog.Default() level — they leave operator-visible
+// orphan state but cannot abort the original error path.
+func (s *Store) rollbackCreate(ctx context.Context, id string) {
+	if _, delErr := s.masterDB.ExecContext(ctx, `DELETE FROM queues WHERE id = ?`, id); delErr != nil {
+		slog.Default().Warn("CreateQueue rollback delete failed", "err", delErr.Error())
+	}
+	if remErr := os.Remove(s.queuePath(id)); remErr != nil && !errors.Is(remErr, os.ErrNotExist) {
+		slog.Default().Warn("CreateQueue rollback remove failed", "err", remErr.Error())
+	}
+	if _, checkErr := s.masterDB.ExecContext(ctx, "PRAGMA wal_checkpoint(FULL)"); checkErr != nil {
+		slog.Default().Warn("CreateQueue rollback wal_checkpoint failed", "err", checkErr.Error())
+	}
+}
+
+// GetQueue returns queue metadata or queue.ErrQueueNotFound.
+func (s *Store) GetQueue(ctx context.Context, id string) (*queue.Queue, error) {
+	q, _, err := s.getQueueWithSalt(ctx, id)
+	return q, err
+}
+
+// getQueueWithSalt returns the queue metadata together with the per-queue
+// salt the caller needs to open the encrypted file.
+func (s *Store) getQueueWithSalt(ctx context.Context, id string) (*queue.Queue, []byte, error) {
 	var (
 		q                                queue.Queue
+		salt                             []byte
 		createdNs, expiresNs, lastAccess int64
 	)
 	row := s.masterDB.QueryRowContext(ctx,
-		`SELECT id, owner_x25519_pub, owner_ed25519_pub, created_at, expires_at, last_access FROM queues WHERE id = ?`, id,
+		`SELECT id, owner_x25519_pub, owner_ed25519_pub, key_salt, created_at, expires_at, last_access FROM queues WHERE id = ?`, id,
 	)
-	if err := row.Scan(&q.ID, &q.OwnerX25519Pub, &q.OwnerEd25519Pub, &createdNs, &expiresNs, &lastAccess); err != nil {
+	if err := row.Scan(&q.ID, &q.OwnerX25519Pub, &q.OwnerEd25519Pub, &salt, &createdNs, &expiresNs, &lastAccess); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, queue.ErrQueueNotFound
+			return nil, nil, queue.ErrQueueNotFound
 		}
-		return nil, err
+		return nil, nil, err
 	}
 	q.CreatedAt = time.Unix(0, createdNs).UTC()
 	q.ExpiresAt = time.Unix(0, expiresNs).UTC()
 	q.LastAccess = time.Unix(0, lastAccess).UTC()
-	return &q, nil
+	return &q, salt, nil
 }
 
 // PutMessage appends an opaque blob to the queue.
@@ -209,18 +435,14 @@ func (s *Store) PutMessage(ctx context.Context, queueID string, blob []byte) (*q
 		return nil, queue.ErrBlobTooLarge
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	lk := s.queueLock(queueID)
+	lk.RLock()
+	defer lk.RUnlock()
 
-	if _, err := s.getQueueLocked(ctx, queueID); err != nil {
-		return nil, err
-	}
-
-	qdb, err := s.openQueue(queueID)
+	_, salt, err := s.getQueueWithSalt(ctx, queueID)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = qdb.Close() }()
 
 	msgID, err := queue.NewMessageID()
 	if err != nil {
@@ -228,11 +450,18 @@ func (s *Store) PutMessage(ctx context.Context, queueID string, blob []byte) (*q
 	}
 	now := time.Now().UTC()
 
-	if _, execErr := qdb.ExecContext(ctx,
-		`INSERT INTO messages(id, blob, received_at) VALUES (?, ?, ?)`,
-		msgID, blob, now.UnixNano(),
-	); execErr != nil {
-		return nil, fmt.Errorf("insert message: %w", execErr)
+	useErr := s.useQueueDB(queueID, salt, func(qdb *sql.DB) error {
+		_, execErr := qdb.ExecContext(ctx,
+			`INSERT INTO messages(id, blob, received_at) VALUES (?, ?, ?)`,
+			msgID, blob, now.UnixNano(),
+		)
+		if execErr != nil {
+			return fmt.Errorf("insert message: %w", execErr)
+		}
+		return nil
+	})
+	if useErr != nil {
+		return nil, useErr
 	}
 
 	if err := s.touchQueue(ctx, queueID, now); err != nil {
@@ -253,47 +482,48 @@ func (s *Store) ListMessages(ctx context.Context, queueID string, limit int) ([]
 		limit = 100
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	lk := s.queueLock(queueID)
+	lk.RLock()
+	defer lk.RUnlock()
 
-	if _, err := s.getQueueLocked(ctx, queueID); err != nil {
-		return nil, false, err
-	}
-
-	qdb, err := s.openQueue(queueID)
+	_, salt, err := s.getQueueWithSalt(ctx, queueID)
 	if err != nil {
 		return nil, false, err
 	}
-	defer func() { _ = qdb.Close() }()
 
-	rows, err := qdb.QueryContext(ctx,
-		`SELECT id, blob, received_at FROM messages ORDER BY received_at ASC LIMIT ?`, limit+1,
+	var (
+		msgs    []*queue.Message
+		hasMore bool
 	)
-	if err != nil {
-		return nil, false, err
-	}
-	defer func() { _ = rows.Close() }()
-
-	var msgs []*queue.Message
-	for rows.Next() {
-		var (
-			m          queue.Message
-			receivedNs int64
+	useErr := s.useQueueDB(queueID, salt, func(qdb *sql.DB) error {
+		rows, queryErr := qdb.QueryContext(ctx,
+			`SELECT id, blob, received_at FROM messages ORDER BY received_at ASC LIMIT ?`, limit+1,
 		)
-		if scanErr := rows.Scan(&m.ID, &m.Blob, &receivedNs); scanErr != nil {
-			return nil, false, scanErr
+		if queryErr != nil {
+			return queryErr
 		}
-		m.QueueID = queueID
-		m.ReceivedAt = time.Unix(0, receivedNs).UTC()
-		msgs = append(msgs, &m)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, false, err
-	}
+		defer func() { _ = rows.Close() }()
 
-	hasMore := len(msgs) > limit
-	if hasMore {
+		for rows.Next() {
+			var (
+				m          queue.Message
+				receivedNs int64
+			)
+			if scanErr := rows.Scan(&m.ID, &m.Blob, &receivedNs); scanErr != nil {
+				return scanErr
+			}
+			m.QueueID = queueID
+			m.ReceivedAt = time.Unix(0, receivedNs).UTC()
+			msgs = append(msgs, &m)
+		}
+		return rows.Err()
+	})
+	if useErr != nil {
+		return nil, false, useErr
+	}
+	if len(msgs) > limit {
 		msgs = msgs[:limit]
+		hasMore = true
 	}
 	if err := s.touchQueue(ctx, queueID, time.Now().UTC()); err != nil {
 		return nil, false, err
@@ -303,26 +533,27 @@ func (s *Store) ListMessages(ctx context.Context, queueID string, limit int) ([]
 
 // DeleteMessage removes a single message from the queue.
 func (s *Store) DeleteMessage(ctx context.Context, queueID, messageID string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	lk := s.queueLock(queueID)
+	lk.RLock()
+	defer lk.RUnlock()
 
-	if _, err := s.getQueueLocked(ctx, queueID); err != nil {
-		return err
-	}
-
-	qdb, err := s.openQueue(queueID)
+	_, salt, err := s.getQueueWithSalt(ctx, queueID)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = qdb.Close() }()
 
-	res, err := qdb.ExecContext(ctx, `DELETE FROM messages WHERE id = ?`, messageID)
-	if err != nil {
-		return err
-	}
-	affected, err := res.RowsAffected()
-	if err != nil {
-		return err
+	var affected int64
+	useErr := s.useQueueDB(queueID, salt, func(qdb *sql.DB) error {
+		res, execErr := qdb.ExecContext(ctx, `DELETE FROM messages WHERE id = ?`, messageID)
+		if execErr != nil {
+			return execErr
+		}
+		var rowsErr error
+		affected, rowsErr = res.RowsAffected()
+		return rowsErr
+	})
+	if useErr != nil {
+		return useErr
 	}
 	if affected == 0 {
 		return queue.ErrMessageNotFound
@@ -338,9 +569,6 @@ func (s *Store) touchQueue(ctx context.Context, queueID string, t time.Time) err
 
 // ExpiredQueueIDs returns queue identifiers whose expires_at is before t.
 func (s *Store) ExpiredQueueIDs(ctx context.Context, t time.Time) ([]string, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	rows, err := s.masterDB.QueryContext(ctx,
 		`SELECT id FROM queues WHERE expires_at < ?`, t.UnixNano())
 	if err != nil {
@@ -359,11 +587,34 @@ func (s *Store) ExpiredQueueIDs(ctx context.Context, t time.Time) ([]string, err
 	return ids, rows.Err()
 }
 
-// DeleteQueue removes a queue's metadata row and its database file.
-// Used by the TTL cleanup goroutine.
+// DeleteQueue removes a queue's database file first, then the metadata
+// row, then forces a WAL checkpoint so the row's salt cannot survive
+// in master.db-wal beyond the call.
+//
+// Removing the file before the row means a partial failure leaves the
+// master row pointing at a missing file — subsequent operations surface
+// that as ErrQueueNotFound, which is the appropriate semantic (the
+// queue has effectively been destroyed). Deleting the row first would
+// risk leaving an orphan file with recoverable content; with
+// crypto-shred the salt also vanishes when the row goes, but the file
+// itself should not survive a successful delete.
+//
+// The wal_checkpoint(FULL) call is the load-bearing piece for the
+// crypto-shred guarantee against backup-style adversaries. Without it,
+// a snapshot taken between DELETE and the next autocheckpoint (default
+// 1000 pages, which a small master.db rarely hits) would still see the
+// salt in the WAL and could decrypt the file.
 func (s *Store) DeleteQueue(ctx context.Context, id string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	lk := s.queueLock(id)
+	lk.Lock()
+	defer lk.Unlock()
+
+	// Drop any cached handle so the OS can actually unlink the file.
+	s.pool.drop(id)
+
+	if removeErr := os.Remove(s.queuePath(id)); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+		return fmt.Errorf("remove queue db file: %w", removeErr)
+	}
 
 	res, err := s.masterDB.ExecContext(ctx, `DELETE FROM queues WHERE id = ?`, id)
 	if err != nil {
@@ -373,8 +624,16 @@ func (s *Store) DeleteQueue(ctx context.Context, id string) error {
 	if affected == 0 {
 		return queue.ErrQueueNotFound
 	}
-	if removeErr := os.Remove(s.queuePath(id)); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-		return fmt.Errorf("remove queue db file: %w", removeErr)
+
+	// Crypto-shred completion: force the salt out of the WAL.
+	if _, checkErr := s.masterDB.ExecContext(ctx, "PRAGMA wal_checkpoint(FULL)"); checkErr != nil {
+		slog.Default().Warn("DeleteQueue wal_checkpoint failed", "err", checkErr.Error())
 	}
+
+	// Drop the per-queue mutex from the map so a long-running server
+	// does not accumulate one entry per ever-deleted queue. A goroutine
+	// still holding a pointer to the now-orphan mutex finishes safely;
+	// any future call for the same id allocates a fresh one.
+	s.queueLocks.Delete(id)
 	return nil
 }

--- a/server/internal/storage/sqlite/store.go
+++ b/server/internal/storage/sqlite/store.go
@@ -27,11 +27,18 @@ const (
 	queueFilenameSuffix = ".db"
 	dataDirPerm         = 0o700
 
-	// masterMaxOpenConns leaves WAL room for a writer plus several
-	// concurrent readers without crossing the typical container ulimit
-	// once per-queue handles are factored in (each WAL DB is 3 FDs:
-	// main, -wal, -shm).
-	masterMaxOpenConns = 8
+	// masterWriterMaxOpenConns is intentionally 1: SQLite serialises
+	// writers anyway, and a single connection eliminates the chance
+	// of SQLITE_BUSY between concurrent INSERT / UPDATE / DELETE
+	// statements going through the writer pool.
+	masterWriterMaxOpenConns = 1
+
+	// masterReaderMaxOpenConns gives reader queries (GetQueue,
+	// ExpiredQueueIDs, getQueueWithSalt) a parallel pool sized for
+	// typical small-server CPU counts. WAL mode lets these readers
+	// proceed against the last committed snapshot without blocking
+	// the writer or each other.
+	masterReaderMaxOpenConns = 4
 
 	// queueMaxOpenConns stays at 1 because per-queue files are
 	// write-mostly and not WAL — there is no concurrent-read benefit
@@ -141,10 +148,11 @@ func (c *cipherConnector) Driver() driver.Driver { return cipherDriver }
 //     (per-queue WAL is currently disabled, so this is a no-op today,
 //     but flip the bit and the same caveat applies).
 type Store struct {
-	seed     MasterSeed
-	dataDir  string
-	masterDB *sql.DB
-	pool     *queueDBPool
+	seed         MasterSeed
+	dataDir      string
+	masterDB     *sql.DB // writer pool, MaxOpenConns=1
+	masterReadDB *sql.DB // reader pool, MaxOpenConns=N (WAL snapshot reads)
+	pool         *queueDBPool
 	// queueLocks serialises operations targeting the same queue.
 	// DeleteQueue takes the write side (exclusive); concurrent
 	// PutMessage / ListMessages / DeleteMessage on the same id share
@@ -164,32 +172,53 @@ func New(seed MasterSeed, dataDir string) (*Store, error) {
 	if mkdirErr := os.MkdirAll(abs, dataDirPerm); mkdirErr != nil {
 		return nil, fmt.Errorf("create dataDir: %w", mkdirErr)
 	}
+	masterPath := filepath.Join(abs, masterFilename)
 	masterDB, err := openEncryptedDB(
-		filepath.Join(abs, masterFilename),
+		masterPath,
 		seed.MasterKey,
 		true,
-		masterMaxOpenConns,
+		masterWriterMaxOpenConns,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("open master.db: %w", err)
+		return nil, fmt.Errorf("open master.db (writer): %w", err)
 	}
 	if _, schemaErr := masterDB.Exec(masterSchema); schemaErr != nil {
 		_ = masterDB.Close()
 		return nil, fmt.Errorf("init master schema: %w", schemaErr)
 	}
+	// Reader pool shares the file via WAL: the writer commits create
+	// fresh snapshots; readers can run concurrently without blocking
+	// each other or the writer.
+	masterReadDB, err := openEncryptedDB(
+		masterPath,
+		seed.MasterKey,
+		false, // WAL is already enabled by the writer; the file metadata persists
+		masterReaderMaxOpenConns,
+	)
+	if err != nil {
+		_ = masterDB.Close()
+		return nil, fmt.Errorf("open master.db (reader): %w", err)
+	}
 	return &Store{
-		seed:     seed,
-		dataDir:  abs,
-		masterDB: masterDB,
-		pool:     newQueueDBPool(queueDBCapacity),
+		seed:         seed,
+		dataDir:      abs,
+		masterDB:     masterDB,
+		masterReadDB: masterReadDB,
+		pool:         newQueueDBPool(queueDBCapacity),
 	}, nil
 }
 
 // Close releases resources held by the store: it drains the per-queue
-// pool first, then closes the master DB handle.
+// pool first, then closes both master DB handles (reader and writer).
+// The first close error is reported; subsequent ones are best-effort.
 func (s *Store) Close() error {
 	s.pool.Close()
-	return s.masterDB.Close()
+	readErr := s.masterReadDB.Close()
+	writeErr := s.masterDB.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	return readErr
 }
 
 const masterSchema = `
@@ -404,14 +433,15 @@ func (s *Store) GetQueue(ctx context.Context, id string) (*queue.Queue, error) {
 }
 
 // getQueueWithSalt returns the queue metadata together with the per-queue
-// salt the caller needs to open the encrypted file.
+// salt the caller needs to open the encrypted file. Reads go through the
+// reader pool so concurrent GetQueue calls don't serialise on the writer.
 func (s *Store) getQueueWithSalt(ctx context.Context, id string) (*queue.Queue, []byte, error) {
 	var (
 		q                                queue.Queue
 		salt                             []byte
 		createdNs, expiresNs, lastAccess int64
 	)
-	row := s.masterDB.QueryRowContext(ctx,
+	row := s.masterReadDB.QueryRowContext(ctx,
 		`SELECT id, owner_x25519_pub, owner_ed25519_pub, key_salt, created_at, expires_at, last_access FROM queues WHERE id = ?`, id,
 	)
 	if err := row.Scan(&q.ID, &q.OwnerX25519Pub, &q.OwnerEd25519Pub, &salt, &createdNs, &expiresNs, &lastAccess); err != nil {
@@ -568,8 +598,10 @@ func (s *Store) touchQueue(ctx context.Context, queueID string, t time.Time) err
 }
 
 // ExpiredQueueIDs returns queue identifiers whose expires_at is before t.
+// Read-only — uses the reader pool so the periodic cleanup tick does not
+// contend with in-flight writes on the master DB.
 func (s *Store) ExpiredQueueIDs(ctx context.Context, t time.Time) ([]string, error) {
-	rows, err := s.masterDB.QueryContext(ctx,
+	rows, err := s.masterReadDB.QueryContext(ctx,
 		`SELECT id FROM queues WHERE expires_at < ?`, t.UnixNano())
 	if err != nil {
 		return nil, err

--- a/server/internal/storage/sqlite/store_test.go
+++ b/server/internal/storage/sqlite/store_test.go
@@ -21,7 +21,7 @@ import (
 	_ "github.com/mutecomm/go-sqlcipher/v4"
 )
 
-func newTestStore(t *testing.T) (*sqlite.Store, string) {
+func newTestStore(t *testing.T) (*sqlite.Store, sqlite.MasterSeed, string) {
 	t.Helper()
 
 	var seed sqlite.MasterSeed
@@ -34,7 +34,7 @@ func newTestStore(t *testing.T) (*sqlite.Store, string) {
 		t.Fatalf("New: %v", err)
 	}
 	t.Cleanup(func() { _ = st.Close() })
-	return st, dir
+	return st, seed, dir
 }
 
 func ownerKeys(t *testing.T) queue.OwnerKeys {
@@ -74,7 +74,7 @@ func TestNew_CreatesDataDir(t *testing.T) {
 
 func TestCreateAndPutAndList_RoundTrip(t *testing.T) {
 	t.Parallel()
-	st, _ := newTestStore(t)
+	st, _, _ := newTestStore(t)
 	ctx := context.Background()
 
 	q, err := st.CreateQueue(ctx, ownerKeys(t))
@@ -176,7 +176,7 @@ func TestEncryptionAtRest_DBFileIsOpaque(t *testing.T) {
 
 func TestPutMessage_QueueNotFound(t *testing.T) {
 	t.Parallel()
-	st, _ := newTestStore(t)
+	st, _, _ := newTestStore(t)
 
 	if _, err := st.PutMessage(context.Background(), "missing-queue-id", []byte("x")); !errors.Is(err, queue.ErrQueueNotFound) {
 		t.Errorf("got %v, want ErrQueueNotFound", err)
@@ -185,7 +185,7 @@ func TestPutMessage_QueueNotFound(t *testing.T) {
 
 func TestPutMessage_RejectsTooLargeAndEmpty(t *testing.T) {
 	t.Parallel()
-	st, _ := newTestStore(t)
+	st, _, _ := newTestStore(t)
 	ctx := context.Background()
 	q, err := st.CreateQueue(ctx, ownerKeys(t))
 	if err != nil {
@@ -201,7 +201,7 @@ func TestPutMessage_RejectsTooLargeAndEmpty(t *testing.T) {
 
 func TestDeleteMessage_RoundTrip(t *testing.T) {
 	t.Parallel()
-	st, _ := newTestStore(t)
+	st, _, _ := newTestStore(t)
 	ctx := context.Background()
 
 	q, err := st.CreateQueue(ctx, ownerKeys(t))
@@ -229,7 +229,7 @@ func TestDeleteMessage_RoundTrip(t *testing.T) {
 
 func TestExpiredAndDeleteQueue(t *testing.T) {
 	t.Parallel()
-	st, dir := newTestStore(t)
+	st, seed, dir := newTestStore(t)
 	ctx := context.Background()
 
 	q, err := st.CreateQueue(ctx, ownerKeys(t))
@@ -247,7 +247,8 @@ func TestExpiredAndDeleteQueue(t *testing.T) {
 	if err := st.DeleteQueue(ctx, q.ID); err != nil {
 		t.Fatalf("DeleteQueue: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(dir, q.ID+".db")); !errors.Is(err, os.ErrNotExist) {
+	queuePath := filepath.Join(dir, seed.QueueFilename(q.ID)+".db")
+	if _, err := os.Stat(queuePath); !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("queue file still exists: %v", err)
 	}
 	if _, err := st.GetQueue(ctx, q.ID); !errors.Is(err, queue.ErrQueueNotFound) {


### PR DESCRIPTION
A series of security improvements layered on top of the SQLCipher persistent storage and Ed25519 challenge-response auth, plus expanded test coverage.

**HTTP server hardening:** ReadTimeout/WriteTimeout/IdleTimeout/MaxHeaderBytes against Slowloris, `signal.Notify` registered before any goroutine starts, `shutdownCleanly` with a bounded `cleanupShutdownTimeout=10s`, log level configurable via `MOLDD_LOG_LEVEL`, listening address only logged at DEBUG.

**Input validation:** `queueIDRegex ^[A-Z2-7]{32}$` in every handler BEFORE the body is read (closes a DoS amplifier), case-insensitive Authorization scheme per RFC 7235, explicit length guard ahead of `subtle.ConstantTimeCompare`, all-zero X25519 reject via constant-time comparison, memory-backend caps `MaxQueues=4096` / `MaxMessagesPerQueue=4096` mapped to 503 Service Unavailable, lazy sweep amortisation in the Issuer.

**SQLCipher hardening:** custom `cipherConnector` via `sql.OpenDB` (PRAGMA key applied per-connection rather than embedded in a long-lived DSN), reader/writer pool split on the master DB (writer with 1 connection, reader with 4 over WAL), `PRAGMA temp_store = MEMORY` per Connect (anti-spill), `syscall.Umask(0o077)` so DB files land at 0600.

**Crypto-shred:** new per-queue `key_salt BLOB` column in the master schema, `DeriveQueueKey(queueID, salt)`. DeleteQueue runs file → master row → `PRAGMA wal_checkpoint(FULL)` so the salt does not survive in `master.db-wal`. CreateQueue rollback is symmetric and emits warning logs on failure.

**Privacy:** filename = `HMAC(seed, queueID)[:16]` with a 256-shard layout (`<hex[:2]>/<rest>.db`) — a directory listing no longer enumerates queue identifiers. The URL path is dropped from the signed payload (canonical form: `domain || nonce || queue_id || method || resource_id`) — signatures no longer depend on proxy path normalisation.

**Concurrency:** per-queue `sync.RWMutex` (RLock for Put/List/Delete, Lock for DeleteQueue), LRU cache of `*sql.DB` per queue with refcount + deferred close + onClose hook that zeroes the per-queue salt buffer on eviction.

**Test coverage:** six fuzz targets with sentinel/determinism invariants, `goleak` in cleanup + api/v1, pool stress test (64 × 50 with opens == closes), eviction race tests, bounded shutdown-timeout test, three benchmarks (Verify ~48µs, ParseAuth ~314ns, Pool acquire-release ~58ns), and an integration test behind a build tag covering the full lifecycle across restart and cleanup.