### PR TITLE
ci: cap release-please query depth to 50 to dodge GraphQL flakes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,9 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # Cap GraphQL query scope to fit a small repo. Defaults
+          # (400 / 500) are sized for monorepos with hundreds of
+          # releases; ours has a handful, and the larger queries
+          # have been observed to trip GitHub-side GraphQL flakes.
+          release-search-depth: 50
+          commit-search-depth: 50


### PR DESCRIPTION
Lowers `release-search-depth` and `commit-search-depth` to 50 (from defaults of 400 and 500). Our repo has only a handful of releases and a few dozen commits; the larger queries have been observed to trigger GitHub-side GraphQL internal errors on the post-merge `release` workflow.