### PR TITLE
revert: drop release-please action inputs that don't exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,3 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          # Cap GraphQL query scope to fit a small repo. Defaults
-          # (400 / 500) are sized for monorepos with hundreds of
-          # releases; ours has a handful, and the larger queries
-          # have been observed to trip GitHub-side GraphQL flakes.
-          release-search-depth: 50
-          commit-search-depth: 50


### PR DESCRIPTION
Reverts c51ddb6. The `release-search-depth` / `commit-search-depth` keys are not inputs of `googleapis/release-please-action@v5` — the action silently ignores them and the logs continue to show the defaults (400 / 500). The previous commit was a no-op and is removed in the interest of an honest workflow file. The GitHub-side GraphQL error on the release workflow needs a different fix (simplifying release-please-config or switching tooling) and will be handled in a follow-up.