### PR TITLE
ci: publish signed container image to ghcr.io on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,79 @@
+# Triggered on component-versioned tag pushes (server-vX.Y.Z).
+# Builds a multi-stage container image, pushes it to ghcr.io with BuildKit
+# SLSA provenance and SBOM attestations, and signs it via keyless cosign.
+name: docker
+
+on:
+  push:
+    tags:
+      - 'server-v*'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/moldd
+          tags: |
+            type=match,pattern=server-v(.*),group=1
+          labels: |
+            org.opencontainers.image.title=moldd
+            org.opencontainers.image.description=MoldChat server
+            org.opencontainers.image.licenses=AGPL-3.0-or-later
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.vendor=WissCore
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: ./server
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003  # v4.1.1
+
+      - name: Sign image (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          for tag in ${TAGS}; do
+            cosign sign --yes "${tag}@${DIGEST}"
+          done

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,5 @@
+**/*_test.go
+**/testdata/
+dist/
+CHANGELOG.md
+README.md

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1.7
+
+# Build stage: full Go toolchain + gcc for CGO (required by go-sqlcipher).
+ARG GO_VERSION=1.26.2
+ARG RUNTIME_IMAGE=gcr.io/distroless/cc-debian12:nonroot
+
+FROM golang:${GO_VERSION}-bookworm AS builder
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
+    go build -trimpath -ldflags="-s -w -buildid=" \
+    -o /out/moldd ./cmd/moldd
+
+# Runtime stage: distroless with glibc + libgcc (CGO needs libc, no shell, no package manager).
+FROM ${RUNTIME_IMAGE} AS runtime
+
+COPY --from=builder /out/moldd /usr/local/bin/moldd
+
+EXPOSE 8080
+USER nonroot:nonroot
+ENTRYPOINT ["/usr/local/bin/moldd"]


### PR DESCRIPTION
## Summary

- New `docker.yml` workflow triggers on `server-v*` tag pushes (same trigger as `sigstore-sign.yml`) and publishes a multi-stage container image to `ghcr.io/wisscore/moldd`.
- Image is built from `golang:1.26-bookworm` (CGO is required by `mutecomm/go-sqlcipher`) and runs on `gcr.io/distroless/cc-debian12:nonroot` — no shell, no package manager, runs as non-root.
- Build emits BuildKit SLSA provenance (`mode=max`) and SBOM attached to the image; the resulting digest is signed with keyless cosign via the workflow's OIDC identity.
- Closes the OpenSSF Scorecard "Packaging" gap (currently `-1`, no publishing workflow detected).

## Notes

- After the first release runs and the package appears under the org's Packages tab, visibility needs to be flipped to **Public** once via the GitHub UI; subsequent versions of the same package inherit that setting.
- Base image references (`golang:1.26.2-bookworm`, `distroless/cc-debian12:nonroot`) use floating tags — Renovate will pin them to digests on its next run.
- Multi-arch (linux/arm64) is intentionally out of scope for this PR; CGO cross-builds need a separate setup. Can be a follow-up.