### PR TITLE
ci: enable manual dispatch for sigstore-sign workflow

### DIFF
--- a/.github/workflows/sigstore-sign.yml
+++ b/.github/workflows/sigstore-sign.yml
@@ -15,6 +15,7 @@ on:
   push:
     tags:
       - 'server-v*'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
- Added `workflow_dispatch` trigger to `sigstore-sign.yml`.