### PR TITLE
feat(server): anonymous credentials, smoke suite, and ci orchestrator

### DIFF
--- a/.github/workflows/backup-roundtrip.yml
+++ b/.github/workflows/backup-roundtrip.yml
@@ -1,26 +1,17 @@
+# Reusable: invoked by .github/workflows/ci.yml as a Tier 3
+# feature-level validation. Spins up MinIO, exercises the full
+# snapshot → restic backup → restore round-trip against a real
+# encrypted SQLCipher store. Heavy enough (~5 minutes) that we
+# defer it behind build-test in the orchestrator so a failed
+# build short-circuits the suite first.
 name: backup-roundtrip
 
 on:
-  pull_request:
-    paths:
-      - 'server/internal/storage/sqlite/**'
-      - 'server/go.mod'
-      - 'server/go.sum'
-      - '.github/workflows/backup-roundtrip.yml'
-  push:
-    branches: [main]
-    paths:
-      - 'server/internal/storage/sqlite/**'
-      - 'server/go.mod'
-      - 'server/go.sum'
-      - '.github/workflows/backup-roundtrip.yml'
+  workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: read
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
 
 jobs:
   roundtrip:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,7 +1,8 @@
-# Reusable: invoked by .github/workflows/ci.yml as a Tier 3
-# feature-level validation. Builds the moldd binary and exercises
-# every smoke case registered in server/internal/smoke/.
-name: smoke
+# Reusable: invoked by .github/workflows/ci.yml as the build-test
+# tier of the orchestrator. Also exposed via workflow_dispatch so
+# operators can re-run just the Go build+test from the Actions UI
+# without re-running the whole CI suite.
+name: build-test
 
 on:
   workflow_call:
@@ -11,10 +12,10 @@ permissions:
   contents: read
 
 jobs:
-  smoke:
-    name: server smoke
+  server:
+    name: server (Go)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: server
@@ -34,8 +35,11 @@ jobs:
         with:
           go-version-file: server/go.mod
 
-      - name: Run smoke suite
-        # Mirrors `mise run smoke` exactly. Adding a new smoke
-        # scenario only requires dropping a *_smoke.go file in
-        # server/internal/smoke/ — no edits here.
-        run: go test -tags smoke -count=1 -timeout=2m ./internal/smoke/...
+      - name: Build
+        run: go build -trimpath ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -race -count=1 -coverprofile=coverage.out ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,31 @@
 name: ci
 
+# Single orchestrator entry point for every PR and every push to main.
+# This is the only PR-triggered workflow in the repository — every
+# other workflow under .github/workflows/ either:
+#
+#   - declares "on: workflow_call:" and is invoked from below by a
+#     `uses:` step, or
+#   - has its own non-PR trigger (release, tag, schedule) and is
+#     deliberately scoped to that lifecycle.
+#
+# Branch protection should require exactly one status check from
+# this file: ci-success. That job depends on every other job in the
+# graph and fails if any of them does not succeed, so a single
+# required check keeps protection rules simple while still gating
+# on the entire suite.
+#
+# Operator migration: when this lands, replace every former
+# per-workflow required status (ci, gitleaks, zizmor, codeql,
+# osv-scanner, dco, smoke, backup-roundtrip) with a single required
+# status named "ci / ci-success". See docs/runbook/branch-protection.md
+# for the operator-facing guide.
+
 on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -13,34 +35,207 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  server:
-    name: server (Go)
+  # Tier 0 — detect which paths changed so the heavy feature
+  # validations (backup-roundtrip, docker) can be skipped on PRs
+  # that don't touch the relevant areas. workflow_call does not
+  # propagate the caller's `paths:` filter to the called workflow,
+  # so the gate has to be a job whose output drives a downstream
+  # `if:`. Implementation is deliberately bash-only — no new
+  # third-party action in the supply chain just for path matching.
+  changed-paths:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    defaults:
-      run:
-        working-directory: server
+    timeout-minutes: 1
+    permissions:
+      contents: read
+    outputs:
+      backup-roundtrip: ${{ steps.filter.outputs.backup-roundtrip }}
+      docker: ${{ steps.filter.outputs.docker }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2
         with:
           egress-policy: audit
-
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
+          fetch-depth: 0
           persist-credentials: false
+      - name: Detect changed paths
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            base="${PR_BASE_SHA}"; head="${PR_HEAD_SHA}"
+          elif [ "${EVENT_NAME}" = "push" ]; then
+            # First push to a new branch reports an all-zero "before"
+            # SHA; in that case fall back to the previous commit so
+            # diff stays well-defined.
+            if [ "${PUSH_BEFORE}" = "0000000000000000000000000000000000000000" ]; then
+              base="${PUSH_AFTER}^"
+            else
+              base="${PUSH_BEFORE}"
+            fi
+            head="${PUSH_AFTER}"
+          else
+            # workflow_dispatch and any future trigger: fail open and
+            # run every gated job. Surprising a developer with skipped
+            # validations on a manual run is worse than a few minutes
+            # of extra runner time.
+            echo "backup-roundtrip=true" >> "${GITHUB_OUTPUT}"
+            echo "docker=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          changed=$(git diff --name-only "${base}" "${head}")
+          echo "Changed files vs ${base}:"
+          echo "${changed//$'\n'/$'\n  '}" | awk 'NF{print "  " $0}'
 
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
-        with:
-          go-version-file: server/go.mod
+          match() {
+            # match <name> <pattern>...; emits "<name>=true|false" to GITHUB_OUTPUT
+            local name="$1"; shift
+            for pattern in "$@"; do
+              if printf '%s\n' "${changed}" | grep -qE "${pattern}"; then
+                echo "${name}=true" >> "${GITHUB_OUTPUT}"
+                echo "  -> ${name}: matched ${pattern}"
+                return
+              fi
+            done
+            echo "${name}=false" >> "${GITHUB_OUTPUT}"
+            echo "  -> ${name}: no match"
+          }
 
-      - name: Build
-        run: go build -trimpath ./...
+          match backup-roundtrip \
+            '^server/internal/storage/sqlite/' \
+            '^server/go\.(mod|sum)$' \
+            '^\.github/workflows/(backup-roundtrip|ci)\.yml$'
 
-      - name: Vet
-        run: go vet ./...
+          match docker \
+            '^server/' \
+            '^\.github/workflows/(docker|ci)\.yml$'
 
-      - name: Test
-        run: go test -race -count=1 -coverprofile=coverage.out ./...
+  # Tier 1 — fast checks that don't need a Go build. Run in parallel
+  # with the security scans so an obvious problem (leaked secret,
+  # missing DCO, malformed workflow) surfaces in seconds instead of
+  # waiting on a 5-minute Go test.
+  gitleaks:
+    uses: ./.github/workflows/gitleaks.yml
+    permissions:
+      contents: read
+
+  dco:
+    # DCO only makes sense on PR events; the called workflow inspects
+    # github.event.pull_request.* which is empty on push-to-main.
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: ./.github/workflows/dco.yml
+    permissions:
+      contents: read
+
+  zizmor:
+    uses: ./.github/workflows/zizmor.yml
+    permissions:
+      contents: read
+      security-events: write
+
+  # Tier 1 — security scans, parallel to fast checks. CodeQL is the
+  # heaviest job in the graph (~10 minutes) so kicking it off
+  # immediately rather than after build-test minimises wall time.
+  codeql:
+    uses: ./.github/workflows/codeql.yml
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+  osv-scanner:
+    uses: ./.github/workflows/osv-scanner.yml
+    permissions:
+      contents: read
+      security-events: write
+
+  # Tier 2 — Go build + race tests. Gated on the Tier 1 fast checks
+  # so a dirty PR does not waste runner time on the slow path.
+  build-test:
+    needs: [gitleaks, zizmor]
+    uses: ./.github/workflows/build-test.yml
+    permissions:
+      contents: read
+
+  # Tier 3 — feature-level validations that need the freshly built
+  # binary or its sources. Each is independent of the others and runs
+  # in parallel as soon as build-test goes green.
+  smoke:
+    needs: build-test
+    uses: ./.github/workflows/smoke.yml
+    permissions:
+      contents: read
+
+  docker:
+    needs: [build-test, changed-paths]
+    if: needs.changed-paths.outputs.docker == 'true'
+    uses: ./.github/workflows/docker.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+  backup-roundtrip:
+    needs: [build-test, changed-paths]
+    if: needs.changed-paths.outputs.backup-roundtrip == 'true'
+    uses: ./.github/workflows/backup-roundtrip.yml
+    permissions:
+      contents: read
+
+  # The single status check branch protection should require. Runs
+  # `if: always()` so it executes even when an upstream job fails;
+  # the python check below translates "any failure or cancellation"
+  # into a non-zero exit. Some jobs are legitimately skipped:
+  #   - dco: gated on event_name == 'pull_request'; skipped on push.
+  #   - docker, backup-roundtrip: gated on the changed-paths filter;
+  #     skipped when no relevant file changed.
+  # Any OTHER skipped status is treated as a failure because it
+  # most likely means an upstream job failed and the dependency
+  # chain unwound, which the python report should surface explicitly.
+  ci-success:
+    name: ci-success
+    needs:
+      - changed-paths
+      - gitleaks
+      - dco
+      - zizmor
+      - codeql
+      - osv-scanner
+      - build-test
+      - smoke
+      - docker
+      - backup-roundtrip
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Verify all required jobs succeeded
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os, sys
+          results = json.loads(os.environ["RESULTS"])
+          allowed_skip = {"dco", "docker", "backup-roundtrip"}
+          failed = []
+          for name, info in results.items():
+              status = info.get("result", "?")
+              print(f"  {name}: {status}")
+              if status in ("failure", "cancelled"):
+                  failed.append(f"{name} ({status})")
+              elif status == "skipped" and name not in allowed_skip:
+                  failed.append(f"{name} (unexpectedly skipped)")
+          if failed:
+              print("::error::CI gate failed: " + ", ".join(failed))
+              sys.exit(1)
+          print("::notice::All required jobs succeeded")
+          PY

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,19 +1,18 @@
+# Reusable: invoked by .github/workflows/ci.yml as a Tier 1 security
+# scan on every PR and main push. Also runs standalone every Monday
+# at 05:23 UTC to re-analyse main with the latest CodeQL database
+# even when no code has changed (catches newly disclosed sinks
+# affecting previously-shipped code).
 name: codeql
 
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+  workflow_call:
+  workflow_dispatch:
   schedule:
     - cron: '23 5 * * 1'  # Monday 05:23 UTC
 
 permissions:
   contents: read
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
 
 jobs:
   analyze:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,15 +1,15 @@
+# Reusable: invoked by .github/workflows/ci.yml as a Tier 1 fast
+# check, gated on github.event_name == 'pull_request' because the
+# job below reads pull_request.base.sha / head.sha which are empty
+# on push events.
 name: dco
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: read
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
 
 jobs:
   dco:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,25 +2,25 @@
 # SLSA provenance and SBOM attestations, and signs it via keyless cosign.
 #
 # Triggers:
-#   push to main when server/ or this workflow change — proves the build is
-#     green and gives OpenSSF Scorecard's packaging probe a successful run on
-#     the default branch (the probe ignores tag-only triggers).
+#   workflow_call — invoked by .github/workflows/ci.yml as a Tier 3
+#     feature-level validation. The push step is naturally skipped
+#     because github.ref on PR / main-push is not a tag.
 #   push of a server-vX.Y.Z tag — actually publishes and signs the image.
+#     This trigger remains independent of ci.yml so a tag push does
+#     not have to wait for the full CI suite.
 #   workflow_dispatch — manual escape hatch (no push).
 #
-# Push to ghcr is gated on tag refs only; default-branch and dispatch runs
-# build the image without publishing.
+# Push to ghcr is gated on tag refs only; PR / main-push / dispatch
+# runs build the image without publishing, which proves the
+# Dockerfile is healthy without producing release artifacts.
 name: docker
 
 on:
+  workflow_call:
+  workflow_dispatch:
   push:
-    branches: [main]
-    paths:
-      - 'server/**'
-      - '.github/workflows/docker.yml'
     tags:
       - 'server-v*'
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,19 +1,16 @@
-# gitleaks is invoked via the binary installed by mise (the version is pinned in
-# .mise.toml + mise.lock), so the local pre-push hook and CI run the exact same
-# scanner with the exact same arguments.
+# Reusable: invoked by .github/workflows/ci.yml as a Tier 1 fast
+# check. gitleaks is invoked via the binary installed by mise (the
+# version is pinned in .mise.toml + mise.lock), so the local
+# pre-push hook and CI run the exact same scanner with the exact
+# same arguments.
 name: gitleaks
 
 on:
-  pull_request:
-  push:
-    branches: [main]
+  workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: read
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
 
 jobs:
   gitleaks:

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,22 +1,22 @@
-# osv-scanner is invoked via the binary installed by mise (the version is pinned in
-# .mise.toml + mise.lock), so the local pre-push hook and CI run the exact same
-# scanner with the exact same arguments.
+# Reusable: invoked by .github/workflows/ci.yml as a Tier 1 security
+# scan on every PR and main push. Also runs standalone every Monday
+# at 05:13 UTC to re-scan main against the freshly updated OSV
+# database (catches new advisories against unchanged dependencies).
+#
+# osv-scanner is invoked via the binary installed by mise (the
+# version is pinned in .mise.toml + mise.lock), so the local
+# pre-push hook and CI run the exact same scanner with the exact
+# same arguments.
 name: osv-scanner
 
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+  workflow_call:
+  workflow_dispatch:
   schedule:
     - cron: '13 5 * * 1'  # Monday 05:13 UTC
 
 permissions:
   contents: read
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
 
 jobs:
   scan:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,43 @@
+name: smoke
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: server smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
+        with:
+          go-version-file: server/go.mod
+
+      - name: Run smoke suite
+        # Mirrors `mise run smoke` exactly. Adding a new smoke
+        # scenario only requires dropping a *_smoke.go file in
+        # server/internal/smoke/ — no edits here.
+        run: go test -tags smoke -count=1 -timeout=2m ./internal/smoke/...

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,17 +1,15 @@
+# Reusable: invoked by .github/workflows/ci.yml as a Tier 1 fast
+# check. zizmor lints the workflow files themselves for actions
+# misuse and supply-chain footguns.
 name: zizmor
 
 on:
-  pull_request:
-  push:
-    branches: [main]
+  workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: read
   security-events: write
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
 
 jobs:
   zizmor:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,6 +53,27 @@ linters:
       disable:
         - fieldalignment
 
+  exclusions:
+    rules:
+      # Smoke tests spawn the moldd binary they themselves built in
+      # TestMain; the path is fully under the suite's control. G204
+      # ("subprocess launched with variable") is a structural false
+      # positive against this pattern. Scope is deliberately narrow:
+      # only the smoke package, only that rule.
+      - path: server/internal/smoke/
+        text: "G204"
+        linters:
+          - gosec
+      # The smoke registry dispatches each case as a top-level test
+      # body; the linter sees the *_smoke.go Run functions as helpers
+      # because they take *testing.T but never call t.Helper(). They
+      # are not helpers — they ARE the test bodies — so a helper
+      # frame skip would degrade failure messages. Scope is narrow:
+      # only the smoke package.
+      - path: server/internal/smoke/
+        linters:
+          - thelper
+
 formatters:
   enable:
     - gofumpt

--- a/.mise.toml
+++ b/.mise.toml
@@ -33,3 +33,7 @@ GOSUMDB  = "sum.golang.org"
 
 # Disable Gradle daemon in CI-like local runs to make builds deterministic
 GRADLE_OPTS = "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=4"
+
+[tasks.smoke]
+description = "Run binary smoke tests against a freshly built moldd. Mirrors the CI smoke job."
+run = "go -C server test -tags smoke -count=1 -timeout=2m ./internal/smoke/..."

--- a/docs/runbook/branch-protection.md
+++ b/docs/runbook/branch-protection.md
@@ -1,0 +1,72 @@
+# Branch protection: required status checks
+
+The `main` branch is gated by a single required status check named
+**`ci / ci-success`**. That check is emitted by the `ci-success` job in
+`.github/workflows/ci.yml`, which depends on every other CI job and
+fails if any of them does not succeed (or is unexpectedly skipped).
+This runbook is the operator-facing reference for keeping branch
+protection in sync with the CI orchestrator.
+
+## Required check
+
+Set on **Settings → Branches → Branch protection rules → main**:
+
+```text
+Require status checks to pass before merging:  enabled
+  ci / ci-success                              required
+```
+
+Nothing else from the `ci` workflow should be listed. Listing
+sub-jobs by name (for example `ci / build-test`) is brittle — those
+names are an implementation detail of the orchestrator's DAG and
+will change as new tiers are added.
+
+The `ci-success` job is the only stable contract: it succeeds when
+the entire CI graph succeeds, and fails otherwise.
+
+## Migrating from per-workflow checks
+
+If the protection rule still lists per-workflow checks from the
+pre-orchestrator era, replace the entire set with the single
+`ci / ci-success` entry. Old check names that should be removed:
+
+- `ci / server (Go)`
+- `gitleaks / gitleaks`
+- `zizmor / zizmor`
+- `codeql / analyze (go)`
+- `osv-scanner / scan`
+- `dco / dco`
+- `smoke / server smoke`
+- `backup-roundtrip / snapshot -> restic -> restore`
+
+Once `ci / ci-success` is required and these are removed, every PR
+shows exactly one mandatory check; drilling into the run reveals the
+full DAG.
+
+## Independent workflows that stay required as themselves
+
+A handful of workflows are not part of the orchestrator and remain
+listed as separate required checks where the rule applied before:
+
+- `dependency-review / dep-review` — runs only on `pull_request`
+  events and uses the GitHub-internal diff API; cannot be invoked
+  via `workflow_call`.
+- `semantic-pr / validate` — validates the PR title against
+  Conventional Commits 1.0; runs on `pull_request` title-edit
+  events independent of the CI pipeline.
+
+These should remain individually required if they were before.
+
+## Adding a new check to the orchestrator
+
+When a new validation joins the CI graph, add it to two places in
+`.github/workflows/ci.yml`:
+
+1. A new top-level job that `uses:` the reusable workflow.
+2. The `needs:` list of the `ci-success` summary job.
+
+If the new job is conditionally skipped (paths filter, event-type
+gate, etc.), also add its name to the `allowed_skip` set in the
+python check inside `ci-success`. Forgetting either step makes the
+new check silently non-blocking — branch protection still passes
+even when the new job fails.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,13 +21,17 @@ pre-commit:
       run: go -C server vet ./...
     golangci-lint:
       glob: "*.go"
-      run: cd server && golangci-lint run ./...
+      # --build-tags smoke makes the linter analyze the smoke
+      # package too; the narrow per-rule exclusions in
+      # .golangci.yml then handle the test-pattern false positives.
+      # gosec runs as part of golangci-lint's enabled linter set;
+      # there is no separate standalone gosec hook because that
+      # would duplicate the work and require a parallel exclusion
+      # config.
+      run: cd server && golangci-lint run --build-tags smoke ./...
       skip:
         - merge
         - rebase
-    gosec:
-      glob: "*.go"
-      run: gosec -quiet ./server/...
     ktlint:
       glob: "*.kt"
       run: ktlint {staged_files}

--- a/server/cmd/moldd/main.go
+++ b/server/cmd/moldd/main.go
@@ -13,6 +13,14 @@
 // "60s") and MOLDD_SNAPSHOT_DIR (an absolute path). Both must be set and the
 // storage backend must be sqlite; an offline tool such as restic is expected
 // to ship the resulting directory to remote storage.
+//
+// Anonymous-credential gating on PUT /v1/queues/{id}/messages is opt-in via
+// MOLDD_ANONAUTH=enforce together with MOLDD_ANONAUTH_DATA_DIR. When enabled
+// the issuer derives its POPRF key from MOLDD_MASTER_SEED and persists
+// pseudonyms in an encrypted SQLite file under the data dir. Tunable knobs:
+// MOLDD_ANONAUTH_EPOCH (Go duration, default 1h), MOLDD_ANONAUTH_PSEUDONYM_TTL
+// (Go duration, default 720h), MOLDD_ANONAUTH_TOKENS_PER_EPOCH (uint32,
+// default 100), MOLDD_ANONAUTH_POW_BITS (1..32, default 20).
 package main
 
 import (
@@ -29,6 +37,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/WissCore/moldchat/server/internal/anonauth"
+	"github.com/WissCore/moldchat/server/internal/anonauth/sqlitestore"
 	v1 "github.com/WissCore/moldchat/server/internal/api/v1"
 	"github.com/WissCore/moldchat/server/internal/auth"
 	"github.com/WissCore/moldchat/server/internal/health"
@@ -84,10 +94,22 @@ func run() int {
 		return 1
 	}
 
+	issuer, verifier, runAnonauthCleanup, closeAnonauth, err := initAnonauth(logger)
+	if err != nil {
+		logger.Error("init anonauth", "err", err.Error())
+		return 1
+	}
+
 	mux := http.NewServeMux()
 	mux.Handle("GET /healthz", health.Handler())
 
-	api := &v1.Server{Storage: store, Auth: auth.NewIssuer(), Logger: logger}
+	api := &v1.Server{
+		Storage:  store,
+		Auth:     auth.NewIssuer(),
+		Logger:   logger,
+		Issuer:   issuer,
+		Verifier: verifier,
+	}
 	api.Mount(mux)
 
 	srv := &http.Server{
@@ -117,10 +139,18 @@ func run() int {
 	// gate is mandatory, not cosmetic. The wait is bounded so a wedged
 	// SQL operation cannot hold the process up forever; if the bound is
 	// exceeded we close the store anyway and let the runtime tear the
-	// goroutines down.
+	// goroutines down. closeAnonauth runs after closeStore so the
+	// pseudonym DB is shut down on the same code path.
 	var runnersWg sync.WaitGroup
 	defer func() {
-		shutdownCleanly(rootCancel, &runnersWg, closeStore, runnersShutdownTimeout, logger)
+		shutdownCleanly(rootCancel, &runnersWg, func() error {
+			storeErr := closeStore()
+			anonErr := closeAnonauth()
+			if storeErr != nil {
+				return storeErr
+			}
+			return anonErr
+		}, runnersShutdownTimeout, logger)
 	}()
 
 	if runCleanup != nil {
@@ -135,6 +165,13 @@ func run() int {
 		go func() {
 			defer runnersWg.Done()
 			runSnapshot(rootCtx)
+		}()
+	}
+	if runAnonauthCleanup != nil {
+		runnersWg.Add(1)
+		go func() {
+			defer runnersWg.Done()
+			runAnonauthCleanup(rootCtx)
 		}()
 	}
 
@@ -249,6 +286,140 @@ func initStorage(logger *slog.Logger) (
 	default:
 		return nil, nil, nil, fmt.Errorf("unknown MOLDD_STORAGE backend: %q (valid: memory, sqlite)", backend)
 	}
+}
+
+// initAnonauth constructs the anonymous-credential issuer/verifier
+// pair when MOLDD_ANONAUTH=enforce. The issuer key and pseudonym
+// database are derived from the same MOLDD_MASTER_SEED already used
+// by the SQLCipher backend, but via a dedicated HKDF info string so
+// the two derivations cannot collide. Returns nil issuer + nil
+// verifier when the feature is disabled (the default), in which case
+// the API server treats the X-Anonauth-Token header as not required.
+//
+// runCleanup is the periodic pseudonym-expiry sweeper; nil when the
+// feature is disabled. closeAnonauth releases the pseudonym backing
+// store; it returns nil when the feature is disabled.
+const defaultAnonauthCleanupInterval = 15 * time.Minute
+
+func initAnonauth(logger *slog.Logger) (
+	issuer *anonauth.Issuer,
+	verifier *anonauth.Verifier,
+	runCleanup func(context.Context),
+	closeAnonauth func() error,
+	err error,
+) {
+	mode := strings.ToLower(strings.TrimSpace(os.Getenv("MOLDD_ANONAUTH")))
+	switch mode {
+	case "", "off", "disabled":
+		return nil, nil, nil, func() error { return nil }, nil
+	case "enforce":
+	default:
+		return nil, nil, nil, nil, fmt.Errorf("MOLDD_ANONAUTH: unknown value %q (valid: off, enforce)", mode)
+	}
+
+	seed, seedErr := sqlite.LoadMasterSeed()
+	if seedErr != nil {
+		return nil, nil, nil, nil, fmt.Errorf("anonauth: %w", seedErr)
+	}
+	dataDir := strings.TrimSpace(os.Getenv("MOLDD_ANONAUTH_DATA_DIR"))
+	if dataDir == "" {
+		return nil, nil, nil, nil, errors.New("anonauth: MOLDD_ANONAUTH_DATA_DIR is required when MOLDD_ANONAUTH=enforce")
+	}
+
+	epochDur, epochErr := durationFromEnv("MOLDD_ANONAUTH_EPOCH", time.Hour)
+	if epochErr != nil {
+		return nil, nil, nil, nil, epochErr
+	}
+	ttlDur, ttlErr := durationFromEnv("MOLDD_ANONAUTH_PSEUDONYM_TTL", 30*24*time.Hour)
+	if ttlErr != nil {
+		return nil, nil, nil, nil, ttlErr
+	}
+	tokensPer, tokErr := uint32FromEnv("MOLDD_ANONAUTH_TOKENS_PER_EPOCH", 100)
+	if tokErr != nil {
+		return nil, nil, nil, nil, tokErr
+	}
+	powBits, powErr := uint8FromEnv("MOLDD_ANONAUTH_POW_BITS", anonauth.DefaultDifficultyBits)
+	if powErr != nil {
+		return nil, nil, nil, nil, powErr
+	}
+	cfg := anonauth.IssuerConfig{
+		Epoch:             epochDur,
+		PseudonymTTL:      ttlDur,
+		TokensPerEpoch:    tokensPer,
+		PoWDifficultyBits: powBits,
+	}
+
+	key, keyErr := anonauth.DeriveIssuerKey(seed[:])
+	if keyErr != nil {
+		return nil, nil, nil, nil, fmt.Errorf("anonauth derive key: %w", keyErr)
+	}
+	store, storeErr := sqlitestore.New([32]byte(seed), dataDir)
+	if storeErr != nil {
+		return nil, nil, nil, nil, fmt.Errorf("anonauth open store: %w", storeErr)
+	}
+	iss, issErr := anonauth.NewIssuer(cfg, key, store)
+	if issErr != nil {
+		_ = store.Close()
+		return nil, nil, nil, nil, fmt.Errorf("anonauth issuer: %w", issErr)
+	}
+	ver, verErr := anonauth.NewVerifier(anonauth.VerifierConfig{Epoch: cfg.Epoch}, key)
+	if verErr != nil {
+		_ = store.Close()
+		return nil, nil, nil, nil, fmt.Errorf("anonauth verifier: %w", verErr)
+	}
+	cleanup := &anonauth.CleanupRunner{
+		Store:    store,
+		Interval: defaultAnonauthCleanupInterval,
+		Logger:   logger,
+	}
+	logger.Info("anonauth enforced",
+		"epoch", cfg.Epoch.String(),
+		"tokens_per_epoch", cfg.TokensPerEpoch,
+		"pseudonym_ttl", cfg.PseudonymTTL.String(),
+		"pow_bits", cfg.PoWDifficultyBits,
+		"cleanup_interval", defaultAnonauthCleanupInterval.String(),
+	)
+	return iss, ver, cleanup.Run, store.Close, nil
+}
+
+// durationFromEnv reads a Go duration from the named env var. An
+// empty value falls back to def; an unparsable value returns an
+// error so the caller can fail startup with a normal exit code
+// rather than panicking the process.
+func durationFromEnv(name string, def time.Duration) (time.Duration, error) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return def, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("env %s: %w", name, err)
+	}
+	return d, nil
+}
+
+func uint32FromEnv(name string, def uint32) (uint32, error) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return def, nil
+	}
+	var v uint64
+	if _, err := fmt.Sscanf(raw, "%d", &v); err != nil || v == 0 || v > uint64(^uint32(0)) {
+		return 0, fmt.Errorf("env %s: invalid uint32 %q", name, raw)
+	}
+	return uint32(v), nil
+}
+
+func uint8FromEnv(name string, def uint8) (uint8, error) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return def, nil
+	}
+	var v uint64
+	if _, err := fmt.Sscanf(raw, "%d", &v); err != nil || v == 0 || v > 255 {
+		return 0, fmt.Errorf("env %s: invalid uint8 %q", name, raw)
+	}
+	return uint8(v), nil
 }
 
 // initSnapshot constructs the periodic snapshot runner when both

--- a/server/go.mod
+++ b/server/go.mod
@@ -3,8 +3,13 @@ module github.com/WissCore/moldchat/server
 go 1.26.2
 
 require (
+	github.com/cloudflare/circl v1.6.3
 	github.com/mutecomm/go-sqlcipher/v4 v4.4.2
+	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.50.0
 )
 
-require go.uber.org/goleak v1.3.0 // indirect
+require (
+	github.com/bwesterb/go-ristretto v1.2.3 // indirect
+	golang.org/x/sys v0.43.0 // indirect
+)

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,3 +1,7 @@
+github.com/bwesterb/go-ristretto v1.2.3 h1:1w53tCkGhCQ5djbat3+MH0BAQ5Kfgbt56UZQ/JMzngw=
+github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
+github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
+github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -6,10 +10,14 @@ github.com/mutecomm/go-sqlcipher/v4 v4.4.2/go.mod h1:mF2UmIpBnzFeBdu/ypTDb/LdbS0
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/server/internal/anonauth/anonauth.go
+++ b/server/internal/anonauth/anonauth.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package anonauth implements anonymous, rate-limited credentials for
+// gating message-send operations.
+//
+// The construction has three pieces:
+//
+//   - Pseudonym registration. A client generates a fresh Ed25519 key pair,
+//     solves a hashcash proof of work over a server-supplied challenge, and
+//     submits the public key. The server stores the public key together
+//     with creation time and a per-epoch token counter. The pseudonym is
+//     long-lived (default 30 days) and acts as the rate-limit handle —
+//     no IP, no fingerprint, no user-supplied identifier is ever recorded.
+//
+//   - Token issuance. The pseudonym signs a fresh blinded element with its
+//     Ed25519 private key. The server verifies the signature, atomically
+//     increments the per-pseudonym counter against the configured per-epoch
+//     limit, and runs a Partial Oblivious PRF (RFC 9497, POPRF mode) over
+//     the blinded element with the current epoch as the public info. The
+//     evaluation plus a DLEQ proof are returned to the client, which
+//     unblinds and finalises the token.
+//
+//     The POPRF info parameter cryptographically binds the token to its
+//     epoch: a token finalised at epoch N produces a different MAC under
+//     epoch N+1, so cross-epoch reuse is detected on verify rather than
+//     by tracking expiry timestamps.
+//
+//   - Token verification. The client presents (input, mac) on a
+//     gated request. The server runs the POPRF FullEvaluate over the
+//     input with the current epoch info, constant-time-compares against
+//     the supplied mac, and consults a bounded spent-set keyed by mac to
+//     prevent single-token replay within the epoch. A one-epoch grace
+//     window allows a token finalised seconds before an epoch boundary to
+//     remain redeemable.
+//
+// The construction provides anonymity for the redemption step (the server
+// learns nothing about which pseudonym redeemed a given token) and a
+// rate limit at issuance (the per-pseudonym counter is the only authority
+// on how many tokens an actor may obtain per epoch). Sybil resistance is
+// best-effort and rests on the cost of solving the hashcash challenge per
+// pseudonym; difficulty is operator-tunable so it can be cranked under
+// active flooding without re-issuing client software.
+//
+// What this package does NOT provide:
+//
+//   - Strong anti-Sybil. Hashcash with SHA-256 grinding is asymmetric (the
+//     server verifies in one hash) but a GPU/ASIC adversary can grind
+//     pseudonyms cheaper than a CPU client. Operators must rely on
+//     external signals (network-level rate caps, abuse heuristics) for
+//     sustained flood resistance; this package supplies the per-pseudonym
+//     ceiling and replay protection only.
+//   - Verifiable per-presentation unlinkability across multiple servers.
+//     A single issuer key is used for all clients in a deployment, which
+//     gives unlinkability among clients sharing that issuer; multi-issuer
+//     federation is out of scope here.
+package anonauth
+
+import "errors"
+
+// Sentinel errors surfaced by the issuer and verifier. Callers MUST NOT
+// distinguish between them in client-visible responses; doing so would
+// turn the API into a side channel that reveals which check rejected a
+// given request. The HTTP layer collapses all of them to a single 401 or
+// 429 with no diagnostic hint in the body.
+var (
+	// ErrPoWInvalid is returned when the supplied hashcash nonce does
+	// not satisfy the configured difficulty against the issued
+	// challenge. Distinguishable in tests, opaque on the wire.
+	ErrPoWInvalid = errors.New("hashcash proof of work invalid")
+
+	// ErrPoWChallengeUnknown is returned when the supplied challenge
+	// id is not in the outstanding-challenge map (expired, never
+	// issued, or already consumed).
+	ErrPoWChallengeUnknown = errors.New("hashcash challenge unknown or expired")
+
+	// ErrPseudonymInvalid is returned for any failure to bind a
+	// request to a registered pseudonym: missing record, malformed
+	// public key, signature mismatch, or expired pseudonym.
+	ErrPseudonymInvalid = errors.New("pseudonym binding invalid")
+
+	// ErrRateLimited is returned when the per-pseudonym per-epoch
+	// counter has already reached the configured ceiling. The HTTP
+	// layer maps this to 429 Too Many Requests.
+	ErrRateLimited = errors.New("pseudonym rate limit reached for current epoch")
+
+	// ErrTokenInvalid is returned when a presented token fails POPRF
+	// FullEvaluate against the current or grace epoch. Wraps both
+	// "wrong mac" and "wrong input length"; clients see one 401.
+	ErrTokenInvalid = errors.New("anonymous token invalid")
+
+	// ErrTokenReplayed is returned when a presented token's mac is
+	// already present in the spent-set for its matching epoch.
+	ErrTokenReplayed = errors.New("anonymous token already spent")
+
+	// ErrIssuerSaturated is returned when the in-memory outstanding
+	// challenge map is full. The HTTP layer maps this to 503 so a
+	// flood spike does not cascade into OOM.
+	ErrIssuerSaturated = errors.New("issuer outstanding challenge cap reached")
+)

--- a/server/internal/anonauth/cleanup.go
+++ b/server/internal/anonauth/cleanup.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package anonauth
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+)
+
+// CleanupRunner periodically asks a PseudonymStore to drop expired
+// pseudonyms. It mirrors the storage-layer cleanup runner pattern so
+// operator-facing behaviour (interval, error handling, log shape) is
+// uniform across the binary.
+type CleanupRunner struct {
+	Store    PseudonymStore
+	Interval time.Duration
+	Logger   *slog.Logger
+}
+
+// Run blocks until ctx is cancelled, calling Tick on every Interval.
+// A non-positive Interval makes Run a no-op so callers can wire the
+// runner in unconditionally and gate it via configuration.
+func (r *CleanupRunner) Run(ctx context.Context) {
+	if r.Interval <= 0 {
+		return
+	}
+	t := time.NewTicker(r.Interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			r.Tick(ctx)
+		}
+	}
+}
+
+// Tick performs one cleanup pass and returns the number of records
+// deleted. Errors are logged but do not stop the runner; transient
+// failures (locked database, disk full) should resolve on the next
+// tick.
+func (r *CleanupRunner) Tick(ctx context.Context) int {
+	deleted, err := r.Store.DeleteExpired(ctx, time.Now().UTC())
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return 0
+		}
+		if r.Logger != nil {
+			r.Logger.LogAttrs(ctx, slog.LevelError, "anonauth cleanup tick failed",
+				slog.String("err", err.Error()),
+			)
+		}
+		return 0
+	}
+	if deleted > 0 && r.Logger != nil {
+		r.Logger.LogAttrs(ctx, slog.LevelInfo, "anonauth cleanup tick complete",
+			slog.Int("deleted", deleted),
+		)
+	}
+	return deleted
+}

--- a/server/internal/anonauth/cleanup_test.go
+++ b/server/internal/anonauth/cleanup_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package anonauth_test
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/WissCore/moldchat/server/internal/anonauth"
+)
+
+// fakeStore is a PseudonymStore stub that records DeleteExpired calls
+// and returns canned values. Used for unit-testing the cleanup
+// runner in isolation from any backend.
+type fakeStore struct {
+	deleted int
+	err     error
+	calls   int
+}
+
+func (f *fakeStore) Register(_ context.Context, _ ed25519.PublicKey, _, _ time.Time) error {
+	return nil
+}
+
+func (f *fakeStore) CheckAndIncrement(_ context.Context, _ ed25519.PublicKey, _ int64, _ uint32, _ time.Time) error {
+	return nil
+}
+
+func (f *fakeStore) DeleteExpired(_ context.Context, _ time.Time) (int, error) {
+	f.calls++
+	return f.deleted, f.err
+}
+
+func (f *fakeStore) Close() error { return nil }
+
+func TestCleanupRunner_TickReportsDeleted(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{deleted: 7}
+	r := &anonauth.CleanupRunner{Store: store, Interval: time.Hour}
+	got := r.Tick(context.Background())
+	if got != 7 {
+		t.Fatalf("Tick returned %d, want 7", got)
+	}
+	if store.calls != 1 {
+		t.Fatalf("calls = %d, want 1", store.calls)
+	}
+}
+
+func TestCleanupRunner_TickHandlesError(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{err: errors.New("boom")}
+	r := &anonauth.CleanupRunner{Store: store, Interval: time.Hour}
+	got := r.Tick(context.Background())
+	if got != 0 {
+		t.Fatalf("Tick on error returned %d, want 0", got)
+	}
+}
+
+func TestCleanupRunner_RunNoopOnZeroInterval(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{}
+	r := &anonauth.CleanupRunner{Store: store, Interval: 0}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Run must return immediately on a non-positive interval
+	r.Run(ctx)
+	if store.calls != 0 {
+		t.Fatalf("Run with zero interval should not call DeleteExpired")
+	}
+}
+
+// freshKey here is package-local to avoid a cross-test dependency
+// with the memory-store tests that also need one.
+func freshKeyForCleanup(tb testing.TB) ed25519.PublicKey {
+	tb.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		tb.Fatalf("ed25519: %v", err)
+	}
+	return pub
+}
+
+func TestCleanupRunner_EndToEndAgainstMemoryStore(t *testing.T) {
+	t.Parallel()
+	store := anonauth.NewMemoryPseudonymStore()
+	now := time.Now()
+	live := freshKeyForCleanup(t)
+	dead := freshKeyForCleanup(t)
+	_ = store.Register(context.Background(), live, now, now.Add(time.Hour))
+	_ = store.Register(context.Background(), dead, now.Add(-2*time.Hour), now.Add(-time.Minute))
+
+	r := &anonauth.CleanupRunner{Store: store, Interval: time.Hour}
+	if got := r.Tick(context.Background()); got != 1 {
+		t.Fatalf("Tick deleted %d, want 1", got)
+	}
+	// The live pseudonym must still be usable after the sweep.
+	if err := store.CheckAndIncrement(context.Background(), live, 0, 1, now); err != nil {
+		t.Fatalf("live pseudonym usable: %v", err)
+	}
+}

--- a/server/internal/anonauth/issuer.go
+++ b/server/internal/anonauth/issuer.go
@@ -1,0 +1,300 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package anonauth
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	"github.com/cloudflare/circl/group"
+	"github.com/cloudflare/circl/oprf"
+)
+
+// IssuerConfig captures the operator-controlled knobs of the issuer.
+// Zero values are not acceptable for any field; NewIssuer rejects an
+// invalid config at construction so the failure surfaces at startup
+// rather than under load.
+type IssuerConfig struct {
+	// Epoch is the wall-clock duration of one rate-limit window.
+	// Tokens are bound to the epoch index in their POPRF info, so a
+	// token issued at epoch N produces a different MAC under epoch
+	// N+1 and cannot be replayed across epochs.
+	Epoch time.Duration
+
+	// PseudonymTTL is how long a freshly registered pseudonym remains
+	// valid for token issuance. Beyond this point CheckAndIncrement
+	// rejects with ErrPseudonymExpired and the client must re-register
+	// (and re-solve a hashcash challenge).
+	PseudonymTTL time.Duration
+
+	// TokensPerEpoch is the per-pseudonym ceiling for one epoch.
+	// Once the counter hits this value the issuer returns
+	// ErrRateLimited until the epoch boundary advances.
+	TokensPerEpoch uint32
+
+	// PoWDifficultyBits is the leading-zero-bits target for the
+	// hashcash challenge a client must solve before registering a
+	// pseudonym. Bounded by [1, MaxDifficultyBits].
+	PoWDifficultyBits uint8
+}
+
+// validate returns a descriptive error for the first invalid field.
+// Errors here are meant for the operator, not for clients, so they
+// carry the field name verbatim.
+func (c IssuerConfig) validate() error {
+	switch {
+	case c.Epoch <= 0:
+		return fmt.Errorf("anonauth: IssuerConfig.Epoch must be > 0")
+	case c.PseudonymTTL <= 0:
+		return fmt.Errorf("anonauth: IssuerConfig.PseudonymTTL must be > 0")
+	case c.TokensPerEpoch == 0:
+		return fmt.Errorf("anonauth: IssuerConfig.TokensPerEpoch must be > 0")
+	case c.PoWDifficultyBits == 0 || c.PoWDifficultyBits > MaxDifficultyBits:
+		return fmt.Errorf("anonauth: IssuerConfig.PoWDifficultyBits must be in [1, %d]", MaxDifficultyBits)
+	}
+	return nil
+}
+
+// Issuer is the server side of pseudonym registration and token
+// issuance. It is safe for concurrent use; serialisation of the
+// per-pseudonym counter happens inside the PseudonymStore.
+type Issuer struct {
+	cfg    IssuerConfig
+	key    *IssuerKey
+	pow    *PoWStore
+	store  PseudonymStore
+	server oprf.PartialObliviousServer
+	now    func() time.Time
+}
+
+// NewIssuer constructs an issuer with the supplied configuration,
+// derived key, and pseudonym backing store. The hashcash store is
+// created internally; the caller does not own it.
+func NewIssuer(cfg IssuerConfig, key *IssuerKey, store PseudonymStore) (*Issuer, error) {
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	if key == nil {
+		return nil, fmt.Errorf("anonauth: IssuerKey is required")
+	}
+	if store == nil {
+		return nil, fmt.Errorf("anonauth: PseudonymStore is required")
+	}
+	pow, err := NewPoWStore(cfg.PoWDifficultyBits)
+	if err != nil {
+		return nil, err
+	}
+	return &Issuer{
+		cfg:    cfg,
+		key:    key,
+		pow:    pow,
+		store:  store,
+		server: oprf.NewPartialObliviousServer(key.Suite(), key.privateKey()),
+		now:    time.Now,
+	}, nil
+}
+
+// Config returns the active configuration for the HTTP layer to
+// surface in challenge responses.
+func (i *Issuer) Config() IssuerConfig { return i.cfg }
+
+// PoWChallenge returns a fresh hashcash challenge.
+func (i *Issuer) PoWChallenge() (PoWChallenge, error) { return i.pow.Issue() }
+
+// IssuerPublicKey returns the marshalled POPRF public key so clients
+// can verify DLEQ proofs returned with each evaluation.
+func (i *Issuer) IssuerPublicKey() ([]byte, error) { return i.key.PublicKey() }
+
+// CurrentEpoch returns the epoch index for the supplied wall-clock
+// time. Exposed so tests can inject a fixed clock; production callers
+// should use the issuer's own clock under the hood. Times before the
+// Unix epoch collapse to epoch 0.
+func (i *Issuer) CurrentEpoch(now time.Time) int64 {
+	return computeEpoch(now, i.cfg.Epoch)
+}
+
+// computeEpoch is the shared epoch-index calculator used by both the
+// issuer and the verifier so the two cannot drift out of sync.
+// Returns 0 for any time at or before the Unix epoch and for any
+// non-positive epoch duration; both inputs are validated upstream
+// (issuer/verifier construction reject epoch <= 0) so reaching the
+// guards here means a misuse from a future caller.
+func computeEpoch(now time.Time, epoch time.Duration) int64 {
+	ns := now.UnixNano()
+	epochNs := int64(epoch)
+	if ns < 0 || epochNs <= 0 {
+		return 0
+	}
+	return ns / epochNs
+}
+
+// EpochInfo encodes the supplied epoch index as the public info
+// parameter that goes into the POPRF Evaluate call. Big-endian
+// fixed-width keeps the encoding canonical and platform-independent.
+// Negative epochs are a programming error: every in-package source of
+// epoch values (computeEpoch, the JSON-decoded IssuanceRequest.Epoch
+// after its issuer-side range check) is non-negative by construction.
+// We panic rather than silently produce a high-bit-set encoding so
+// the bug surfaces at the call site instead of as a mysterious
+// FullEvaluate mismatch on the verification side.
+func EpochInfo(epoch int64) []byte {
+	if epoch < 0 {
+		panic("anonauth: EpochInfo called with negative epoch")
+	}
+	out := make([]byte, 8)
+	binary.BigEndian.PutUint64(out, uint64(epoch))
+	return out
+}
+
+// RegisterPseudonym verifies a hashcash submission and persists a
+// fresh pseudonym keyed by the supplied Ed25519 public key. The PoW
+// challenge is consumed atomically — a successful registration
+// removes the challenge so it cannot be reused for a second
+// pseudonym. The supplied public key MUST be 32 bytes; any deviation
+// is rejected as ErrPseudonymInvalid.
+func (i *Issuer) RegisterPseudonym(ctx context.Context, pub ed25519.PublicKey, challenge, nonce []byte) error {
+	if len(pub) != ed25519.PublicKeySize {
+		return ErrPseudonymInvalid
+	}
+	if err := i.pow.Verify(challenge, nonce); err != nil {
+		return err
+	}
+	now := i.now()
+	return i.store.Register(ctx, pub, now, now.Add(i.cfg.PseudonymTTL))
+}
+
+// IssuanceRequest bundles everything the client sends with a token
+// issuance request. Blinded is the marshalled compressed-point form
+// of the POPRF blinded element; PseudonymPub is the registered
+// Ed25519 public key; Signature is the Ed25519 signature over the
+// canonical issuance payload (see canonicalIssuancePayload).
+type IssuanceRequest struct {
+	Blinded      []byte
+	PseudonymPub ed25519.PublicKey
+	Signature    []byte
+	Epoch        int64
+}
+
+// IssuanceResponse is the server's reply. Evaluation is the
+// marshalled compressed-point form of the POPRF evaluation; ProofC
+// and ProofS are the DLEQ proof scalars the client needs for
+// Finalize.
+type IssuanceResponse struct {
+	Evaluation []byte
+	ProofC     []byte
+	ProofS     []byte
+	Epoch      int64
+	IssuedAt   time.Time
+}
+
+// canonicalIssuancePayload is the byte string the client signs and
+// the server verifies. Format:
+//
+//	"moldd-anonauth-issue-v1" || 0x00 || epoch_be_uint64 || 0x00 || blinded
+//
+// Length-prefixing is unnecessary because epoch is fixed-width and
+// blinded comes last; the leading domain tag prevents cross-protocol
+// signature reuse against any other Ed25519 signing context the
+// client might have.
+func canonicalIssuancePayload(epoch int64, blinded []byte) []byte {
+	const tag = "moldd-anonauth-issue-v1"
+	out := make([]byte, 0, len(tag)+1+8+1+len(blinded))
+	out = append(out, tag...)
+	out = append(out, 0)
+	out = append(out, EpochInfo(epoch)...)
+	out = append(out, 0)
+	out = append(out, blinded...)
+	return out
+}
+
+// IssueToken runs the full issuance flow for one request.
+//
+//  1. Verify the supplied epoch matches the server's current epoch
+//     (a one-epoch tolerance window is intentionally NOT applied
+//     here — issuance is bound to the present, not the recent past,
+//     so a client whose clock is skewed re-fetches a challenge).
+//  2. Verify the Ed25519 signature against the canonical payload.
+//  3. Atomically check-and-increment the per-pseudonym counter.
+//  4. Run POPRF.Evaluate with the epoch as info.
+//  5. Marshal the evaluation element and the DLEQ proof scalars.
+func (i *Issuer) IssueToken(ctx context.Context, req IssuanceRequest) (*IssuanceResponse, error) {
+	now := i.now()
+	currentEpoch := i.CurrentEpoch(now)
+	if req.Epoch != currentEpoch {
+		return nil, ErrPseudonymInvalid
+	}
+	if len(req.PseudonymPub) != ed25519.PublicKeySize {
+		return nil, ErrPseudonymInvalid
+	}
+	payload := canonicalIssuancePayload(req.Epoch, req.Blinded)
+	if !ed25519.Verify(req.PseudonymPub, payload, req.Signature) {
+		return nil, ErrPseudonymInvalid
+	}
+	// Validate the blinded element BEFORE consuming the per-epoch
+	// counter slot. A malformed element from a registered client must
+	// not cost the client a token of their quota; the signature has
+	// already proved the request is theirs, so the failure mode is
+	// "bad client encoding" rather than a flooding attempt and the
+	// fair response is to reject without charging.
+	suite := i.key.Suite()
+	blinded := suite.Group().NewElement()
+	if err := blinded.UnmarshalBinary(req.Blinded); err != nil {
+		return nil, fmt.Errorf("anonauth: unmarshal blinded element: %w", err)
+	}
+	if err := i.store.CheckAndIncrement(ctx, req.PseudonymPub, currentEpoch, i.cfg.TokensPerEpoch, now); err != nil {
+		return nil, err
+	}
+
+	evalReq := &oprf.EvaluationRequest{Elements: []group.Element{blinded}}
+	evaluation, err := i.server.Evaluate(evalReq, EpochInfo(currentEpoch))
+	if err != nil {
+		return nil, fmt.Errorf("anonauth: poprf evaluate: %w", err)
+	}
+	if len(evaluation.Elements) != 1 {
+		return nil, fmt.Errorf("anonauth: unexpected evaluation arity %d", len(evaluation.Elements))
+	}
+	evalBytes, err := evaluation.Elements[0].MarshalBinaryCompress()
+	if err != nil {
+		return nil, fmt.Errorf("anonauth: marshal evaluation: %w", err)
+	}
+	proofBytes, err := evaluation.Proof.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("anonauth: marshal proof: %w", err)
+	}
+	c, s, err := splitDLEQProof(proofBytes, suite)
+	if err != nil {
+		return nil, err
+	}
+	return &IssuanceResponse{
+		Evaluation: evalBytes,
+		ProofC:     c,
+		ProofS:     s,
+		Epoch:      currentEpoch,
+		IssuedAt:   now,
+	}, nil
+}
+
+// splitDLEQProof breaks the DLEQ proof's MarshalBinary output into
+// its (c, s) scalar halves. circl writes both scalars concatenated
+// in their fixed-width compressed form; the suite's group dictates
+// the scalar byte length so the split point is deterministic.
+func splitDLEQProof(raw []byte, suite oprf.Suite) (c, s []byte, err error) {
+	scalarLenU := suite.Group().Params().ScalarLength
+	// ScalarLength is the byte width of a group scalar, bounded by
+	// the curve definition (≤ 64 bytes for any of the supported
+	// suites). The explicit cap turns a future suite with an absurd
+	// scalar size into an error rather than a silent panic.
+	if scalarLenU > 1024 {
+		return nil, nil, fmt.Errorf("anonauth: implausible scalar length %d", scalarLenU)
+	}
+	scalarLen := int(scalarLenU)
+	if len(raw) != 2*scalarLen {
+		return nil, nil, fmt.Errorf("anonauth: dleq proof length %d not 2*scalar (%d)", len(raw), scalarLen)
+	}
+	return raw[:scalarLen], raw[scalarLen:], nil
+}

--- a/server/internal/anonauth/keys.go
+++ b/server/internal/anonauth/keys.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package anonauth
+
+import (
+	"fmt"
+
+	"github.com/cloudflare/circl/oprf"
+)
+
+// MasterSeedBytes is the length of the seed material consumed by
+// DeriveIssuerKey. It is intentionally identical to the storage layer
+// seed length so callers can reuse the same secret without truncating
+// or padding.
+const MasterSeedBytes = 32
+
+// issuerKeyInfo is the HKDF info string used to derive the POPRF
+// issuer private key. The "v1" suffix is a key-versioning hook: any
+// future change to the derivation path (suite, mode, or info layout)
+// MUST bump the version so a key rotated under the new scheme cannot
+// collide with one derived under the old scheme.
+const issuerKeyInfo = "moldd-anonauth-issuer-key-v1"
+
+// IssuerKey wraps the POPRF private key together with its public
+// counterpart. The private key never leaves the process and is wiped
+// on Close; the public key is exposed via PublicKey for clients to use
+// during Finalize verification.
+type IssuerKey struct {
+	private *oprf.PrivateKey
+	public  *oprf.PublicKey
+	suite   oprf.Suite
+}
+
+// Suite is the POPRF suite chosen for the deployment. Ristretto255
+// with SHA-512 produces 32-byte group elements and 64-byte finalised
+// outputs; the smaller group elements keep the issued evaluation
+// payload compact, and Ristretto255 has no cofactor concerns that the
+// server has to mitigate.
+func Suite() oprf.Suite { return oprf.SuiteRistretto255 }
+
+// DeriveIssuerKey produces the deterministic POPRF private key used
+// by the issuer. The derivation goes through circl's DeriveKey,
+// which already runs HashToScalar with a domain-separated DST tag
+// over the seed and info string; layering an additional HKDF on top
+// would not strengthen anything but would be one more place a future
+// reviewer must understand. The version-tagged info string namespaces
+// this key from any other future use of the same seed.
+func DeriveIssuerKey(seed []byte) (*IssuerKey, error) {
+	if len(seed) != MasterSeedBytes {
+		return nil, fmt.Errorf("anonauth: seed must be %d bytes", MasterSeedBytes)
+	}
+	suite := Suite()
+	priv, err := oprf.DeriveKey(suite, oprf.PartialObliviousMode, seed, []byte(issuerKeyInfo))
+	if err != nil {
+		return nil, fmt.Errorf("anonauth: derive issuer key: %w", err)
+	}
+	return &IssuerKey{private: priv, public: priv.Public(), suite: suite}, nil
+}
+
+// PublicKey returns the marshalled compressed-point form of the
+// issuer's public key. Clients embed this in their POPRF.Finalize
+// step to verify the DLEQ proof returned with each evaluation, which
+// is what guarantees that all clients see the same key (and therefore
+// cannot be partitioned by per-client key choice).
+func (k *IssuerKey) PublicKey() ([]byte, error) {
+	return k.public.MarshalBinary()
+}
+
+// Suite returns the POPRF suite this key was derived for.
+func (k *IssuerKey) Suite() oprf.Suite { return k.suite }
+
+// privateKey is package-internal so the issuance handler can pass it
+// to the POPRF server without exporting the raw key material.
+func (k *IssuerKey) privateKey() *oprf.PrivateKey { return k.private }

--- a/server/internal/anonauth/keys_test.go
+++ b/server/internal/anonauth/keys_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package anonauth_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/WissCore/moldchat/server/internal/anonauth"
+)
+
+func TestDeriveIssuerKey_Deterministic(t *testing.T) {
+	t.Parallel()
+	seed := bytes.Repeat([]byte{0xAB}, 32)
+	a, err := anonauth.DeriveIssuerKey(seed)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	b, err := anonauth.DeriveIssuerKey(seed)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	pubA, err := a.PublicKey()
+	if err != nil {
+		t.Fatalf("pub a: %v", err)
+	}
+	pubB, err := b.PublicKey()
+	if err != nil {
+		t.Fatalf("pub b: %v", err)
+	}
+	if !bytes.Equal(pubA, pubB) {
+		t.Fatalf("derivation non-deterministic: %x vs %x", pubA, pubB)
+	}
+}
+
+func TestDeriveIssuerKey_DifferentSeedsDifferentKeys(t *testing.T) {
+	t.Parallel()
+	a, err := anonauth.DeriveIssuerKey(bytes.Repeat([]byte{0x01}, 32))
+	if err != nil {
+		t.Fatalf("a: %v", err)
+	}
+	b, err := anonauth.DeriveIssuerKey(bytes.Repeat([]byte{0x02}, 32))
+	if err != nil {
+		t.Fatalf("b: %v", err)
+	}
+	pubA, _ := a.PublicKey()
+	pubB, _ := b.PublicKey()
+	if bytes.Equal(pubA, pubB) {
+		t.Fatalf("two seeds produced same public key, derivation is not injective")
+	}
+}
+
+func TestDeriveIssuerKey_RejectsBadSeedLength(t *testing.T) {
+	t.Parallel()
+	cases := [][]byte{
+		nil,
+		make([]byte, 0),
+		make([]byte, 31),
+		make([]byte, 33),
+		make([]byte, 64),
+	}
+	for _, seed := range cases {
+		if _, err := anonauth.DeriveIssuerKey(seed); err == nil {
+			t.Errorf("expected error for seed length %d, got nil", len(seed))
+		}
+	}
+}

--- a/server/internal/anonauth/pow.go
+++ b/server/internal/anonauth/pow.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package anonauth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"sync"
+	"time"
+)
+
+// Hashcash parameters. The challenge is a fresh 32-byte random value;
+// the client searches for an 8-byte nonce such that the SHA-256 hash
+// of the concatenation has at least DifficultyBits leading zero bits.
+// Difficulty is set at construction; changing it requires a restart,
+// which is acceptable because difficulty changes are rare and a
+// rolling restart is the standard response to a sustained flood.
+const (
+	// challengeBytes is the size of the random challenge handed out by
+	// the issuer. 32 bytes is overkill for collision resistance at any
+	// reasonable issuance rate; the size matches a SHA-256 block so a
+	// challenge plus an 8-byte nonce hashes in a single compression.
+	challengeBytes = 32
+
+	// nonceBytes is the size of the client-supplied nonce. 8 bytes
+	// gives 2^64 search space, far above any difficulty an operator
+	// would set, so the nonce field itself is never the bottleneck.
+	nonceBytes = 8
+
+	// challengeTTL bounds how long an issued challenge remains
+	// redeemable. A short TTL caps the in-memory map and stops a
+	// client from pre-computing a large stockpile of nonces against
+	// future challenges.
+	challengeTTL = 2 * time.Minute
+
+	// MaxOutstandingChallenges caps the in-memory challenge map. The
+	// cap is generous enough for normal client behaviour and small
+	// enough to bound memory under flooding; once reached, Issue
+	// returns ErrIssuerSaturated and the HTTP layer surfaces a 503.
+	MaxOutstandingChallenges = 10_000
+
+	// DefaultDifficultyBits is the default leading-zero-bits target.
+	// On a modern CPU a SHA-256 grind hits 2^20 in roughly one second,
+	// which is a manageable one-time cost per pseudonym.
+	DefaultDifficultyBits = 20
+
+	// MaxDifficultyBits caps how high operators can crank the knob.
+	// 32 bits ≈ 4 billion attempts which already takes minutes on a
+	// CPU; anything above that crosses into UX-hostile territory and
+	// is rejected at config-load time rather than allowed to brick
+	// pseudonym registration.
+	MaxDifficultyBits = 32
+)
+
+// PoWChallenge is what the issuer hands the client. Bytes is the
+// random nonce; DifficultyBits is the leading-zero-bits target the
+// client must hit; ExpiresAt is the wall-clock deadline after which
+// the verifier rejects the submission.
+type PoWChallenge struct {
+	Bytes          []byte
+	DifficultyBits uint8
+	ExpiresAt      time.Time
+}
+
+// PoWStore tracks outstanding challenges. The store is in-memory,
+// bounded, and self-pruning: each successful Issue lazily evicts
+// expired entries, and the Verify call atomically removes the entry
+// it consumes so the same challenge cannot be redeemed twice. The
+// store is not durable across restarts — challenges become invalid on
+// process restart, which is the intended semantics (no challenge
+// outlives the process that issued it).
+type PoWStore struct {
+	mu             sync.Mutex
+	difficultyBits uint8
+	outstanding    map[string]time.Time
+	now            func() time.Time
+}
+
+// NewPoWStore returns a fresh PoWStore configured at the supplied
+// leading-zero-bits target. A zero or out-of-range difficulty is a
+// configuration error and is rejected here rather than at every
+// Issue call so misconfiguration surfaces at startup.
+func NewPoWStore(difficultyBits uint8) (*PoWStore, error) {
+	if difficultyBits == 0 || difficultyBits > MaxDifficultyBits {
+		return nil, ErrPoWInvalid
+	}
+	return &PoWStore{
+		difficultyBits: difficultyBits,
+		outstanding:    make(map[string]time.Time),
+		now:            time.Now,
+	}, nil
+}
+
+// Issue returns a fresh challenge and remembers it until Verify
+// consumes it or it expires. The store is pruned of expired entries
+// only when the cap is reached so the fast path stays O(1).
+func (s *PoWStore) Issue() (PoWChallenge, error) {
+	bytes := make([]byte, challengeBytes)
+	if _, err := rand.Read(bytes); err != nil {
+		return PoWChallenge{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+	if len(s.outstanding) >= MaxOutstandingChallenges {
+		for k, exp := range s.outstanding {
+			if !exp.After(now) {
+				delete(s.outstanding, k)
+			}
+		}
+		if len(s.outstanding) >= MaxOutstandingChallenges {
+			return PoWChallenge{}, ErrIssuerSaturated
+		}
+	}
+
+	expiresAt := now.Add(challengeTTL)
+	s.outstanding[string(bytes)] = expiresAt
+	return PoWChallenge{
+		Bytes:          bytes,
+		DifficultyBits: s.difficultyBits,
+		ExpiresAt:      expiresAt,
+	}, nil
+}
+
+// Verify checks that the supplied nonce satisfies the difficulty
+// against the stored challenge and consumes the challenge. The
+// challenge is removed regardless of outcome: a single challenge must
+// authorise at most one verification attempt so a client cannot grind
+// alternative nonces after a near-miss.
+func (s *PoWStore) Verify(challenge, nonce []byte) error {
+	if len(challenge) != challengeBytes || len(nonce) != nonceBytes {
+		return ErrPoWInvalid
+	}
+
+	s.mu.Lock()
+	expiresAt, ok := s.outstanding[string(challenge)]
+	if !ok {
+		s.mu.Unlock()
+		return ErrPoWChallengeUnknown
+	}
+	delete(s.outstanding, string(challenge))
+	difficulty := s.difficultyBits
+	now := s.now()
+	s.mu.Unlock()
+
+	if !expiresAt.After(now) {
+		return ErrPoWChallengeUnknown
+	}
+	if !satisfiesDifficulty(challenge, nonce, difficulty) {
+		return ErrPoWInvalid
+	}
+	return nil
+}
+
+// satisfiesDifficulty reports whether SHA-256(challenge || nonce) has
+// at least bits leading zero bits. Implemented byte-then-bit so the
+// loop short-circuits on the first non-zero bit and runs in constant
+// time relative to bits — there is nothing secret to leak through
+// timing here, but uniform structure keeps the function
+// straightforward to audit.
+func satisfiesDifficulty(challenge, nonce []byte, bits uint8) bool {
+	h := sha256.New()
+	_, _ = h.Write(challenge)
+	_, _ = h.Write(nonce)
+	digest := h.Sum(nil)
+
+	full := int(bits / 8)
+	for i := 0; i < full; i++ {
+		if digest[i] != 0 {
+			return false
+		}
+	}
+	rem := bits % 8
+	if rem == 0 {
+		return true
+	}
+	mask := byte(0xFF) << (8 - rem)
+	return digest[full]&mask == 0
+}

--- a/server/internal/anonauth/pow_test.go
+++ b/server/internal/anonauth/pow_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package anonauth_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	"github.com/WissCore/moldchat/server/internal/anonauth"
+)
+
+// solvePoW grinds nonces sequentially until SHA-256(challenge||nonce)
+// has at least bits leading zero bits. Test-only helper; production
+// clients run the same loop in their own code.
+func solvePoW(tb testing.TB, challenge []byte, bits uint8) []byte {
+	tb.Helper()
+	nonce := make([]byte, 8)
+	for i := uint64(0); ; i++ {
+		binary.BigEndian.PutUint64(nonce, i)
+		h := sha256.Sum256(append(append([]byte{}, challenge...), nonce...))
+		if leadingZeroBits(h[:]) >= int(bits) {
+			return append([]byte{}, nonce...)
+		}
+		if i > 1<<28 {
+			tb.Fatalf("pow grinding exceeded budget at bits=%d", bits)
+		}
+	}
+}
+
+func leadingZeroBits(b []byte) int {
+	n := 0
+	for _, x := range b {
+		if x == 0 {
+			n += 8
+			continue
+		}
+		for mask := byte(0x80); mask != 0; mask >>= 1 {
+			if x&mask == 0 {
+				n++
+			} else {
+				return n
+			}
+		}
+		return n
+	}
+	return n
+}
+
+func TestPoW_HappyPath(t *testing.T) {
+	t.Parallel()
+	store, err := anonauth.NewPoWStore(8)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	ch, err := store.Issue()
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	if len(ch.Bytes) == 0 {
+		t.Fatalf("empty challenge")
+	}
+	nonce := solvePoW(t, ch.Bytes, ch.DifficultyBits)
+	if err := store.Verify(ch.Bytes, nonce); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+}
+
+func TestPoW_InvalidNonce(t *testing.T) {
+	t.Parallel()
+	store, err := anonauth.NewPoWStore(8)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	ch, _ := store.Issue()
+	bad := bytes.Repeat([]byte{0xFF}, 8)
+	if err := store.Verify(ch.Bytes, bad); !errors.Is(err, anonauth.ErrPoWInvalid) {
+		t.Fatalf("expected ErrPoWInvalid, got %v", err)
+	}
+}
+
+func TestPoW_ChallengeConsumed(t *testing.T) {
+	t.Parallel()
+	store, err := anonauth.NewPoWStore(4)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	ch, _ := store.Issue()
+	nonce := solvePoW(t, ch.Bytes, ch.DifficultyBits)
+	if err := store.Verify(ch.Bytes, nonce); err != nil {
+		t.Fatalf("first verify: %v", err)
+	}
+	// Second attempt with same challenge must be rejected as
+	// unknown — the entry was consumed atomically.
+	if err := store.Verify(ch.Bytes, nonce); !errors.Is(err, anonauth.ErrPoWChallengeUnknown) {
+		t.Fatalf("expected ErrPoWChallengeUnknown on replay, got %v", err)
+	}
+}
+
+func TestPoW_NearMissBurnsChallenge(t *testing.T) {
+	t.Parallel()
+	store, err := anonauth.NewPoWStore(8)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	ch, _ := store.Issue()
+	bad := make([]byte, 8) // almost certainly does not satisfy 8 bits
+	if err := store.Verify(ch.Bytes, bad); !errors.Is(err, anonauth.ErrPoWInvalid) {
+		t.Fatalf("expected ErrPoWInvalid, got %v", err)
+	}
+	// The challenge must be burned so a second attempt with a
+	// freshly ground correct nonce cannot succeed.
+	good := solvePoW(t, ch.Bytes, ch.DifficultyBits)
+	if err := store.Verify(ch.Bytes, good); !errors.Is(err, anonauth.ErrPoWChallengeUnknown) {
+		t.Fatalf("expected ErrPoWChallengeUnknown after near-miss burn, got %v", err)
+	}
+}
+
+func TestPoW_RejectsZeroDifficulty(t *testing.T) {
+	t.Parallel()
+	if _, err := anonauth.NewPoWStore(0); err == nil {
+		t.Fatal("expected error for difficulty 0")
+	}
+	if _, err := anonauth.NewPoWStore(255); err == nil {
+		t.Fatal("expected error for difficulty above max")
+	}
+}
+
+func TestPoW_RejectsBadSizes(t *testing.T) {
+	t.Parallel()
+	store, _ := anonauth.NewPoWStore(4)
+	if err := store.Verify(make([]byte, 31), make([]byte, 8)); err == nil {
+		t.Fatal("expected error for short challenge")
+	}
+	if err := store.Verify(make([]byte, 32), make([]byte, 7)); err == nil {
+		t.Fatal("expected error for short nonce")
+	}
+}

--- a/server/internal/anonauth/pseudonym.go
+++ b/server/internal/anonauth/pseudonym.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package anonauth
+
+import (
+	"context"
+	"crypto/ed25519"
+	"errors"
+	"time"
+)
+
+// PseudonymStore is the persistence interface the issuer uses to
+// register pseudonyms and bookkeep per-epoch counters.
+//
+// Concurrency: implementations MUST serialise CheckAndIncrement so
+// that two parallel token requests under the same pseudonym in the
+// same epoch never both succeed past the configured limit.
+type PseudonymStore interface {
+	// Register persists a fresh pseudonym. Returns ErrPseudonymExists
+	// if the public key is already registered.
+	Register(ctx context.Context, pub ed25519.PublicKey, created, expires time.Time) error
+
+	// CheckAndIncrement atomically rolls the per-epoch counter
+	// forward to the supplied epoch (resetting it when the epoch
+	// differs from the row's stored last_epoch) and increments by
+	// one. Returns ErrRateLimited when the post-increment value
+	// would exceed limit, ErrPseudonymExpired when now is past the
+	// pseudonym's expiry, and ErrPseudonymInvalid when the pseudonym
+	// is unknown.
+	CheckAndIncrement(ctx context.Context, pub ed25519.PublicKey, epoch int64, limit uint32, now time.Time) error
+
+	// DeleteExpired removes pseudonym records whose expiry is at or
+	// before the supplied cutoff. The periodic cleanup runner calls
+	// this; implementations may treat it as best-effort.
+	DeleteExpired(ctx context.Context, before time.Time) (int, error)
+
+	// Close releases any backend resources. Calling Close on a store
+	// that is already closed is a no-op.
+	Close() error
+}
+
+// Sentinel errors specific to the pseudonym store. The HTTP layer
+// collapses them into a single client response per the package-level
+// note in anonauth.go, but the distinct values are useful for tests
+// and storage backends.
+var (
+	ErrPseudonymExists   = errors.New("pseudonym already registered")
+	ErrPseudonymExpired  = errors.New("pseudonym expired")
+	ErrPseudonymCapacity = errors.New("pseudonym store at capacity")
+)

--- a/server/internal/anonauth/pseudonym_memory.go
+++ b/server/internal/anonauth/pseudonym_memory.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package anonauth
+
+import (
+	"context"
+	"crypto/ed25519"
+	"sync"
+	"time"
+)
+
+// MemoryPseudonymStoreCapacity bounds the in-memory pseudonym map so
+// a misconfigured deployment cannot grow without bound. Once reached,
+// Register returns ErrPseudonymCapacity and the HTTP layer surfaces a
+// 503 Service Unavailable.
+const MemoryPseudonymStoreCapacity = 100_000
+
+// pseudonymRecord is the in-memory representation of a registered
+// pseudonym; package-private because no caller outside the store
+// needs to see the per-epoch counter directly.
+type pseudonymRecord struct {
+	expires         time.Time
+	lastEpoch       int64
+	tokensThisEpoch uint32
+}
+
+// memoryPseudonymStore is the in-memory PseudonymStore. Suitable for
+// tests and short-lived development instances; production deployments
+// should run the SQLCipher-backed store from the sqlitestore
+// subpackage.
+type memoryPseudonymStore struct {
+	mu       sync.Mutex
+	capacity int
+	records  map[string]*pseudonymRecord
+}
+
+// NewMemoryPseudonymStore returns an empty in-memory store.
+func NewMemoryPseudonymStore() PseudonymStore {
+	return &memoryPseudonymStore{
+		capacity: MemoryPseudonymStoreCapacity,
+		records:  make(map[string]*pseudonymRecord),
+	}
+}
+
+func (s *memoryPseudonymStore) Register(_ context.Context, pub ed25519.PublicKey, _ time.Time, expires time.Time) error {
+	if len(pub) != ed25519.PublicKeySize {
+		return ErrPseudonymInvalid
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := string(pub)
+	if _, exists := s.records[key]; exists {
+		return ErrPseudonymExists
+	}
+	if len(s.records) >= s.capacity {
+		return ErrPseudonymCapacity
+	}
+	s.records[key] = &pseudonymRecord{expires: expires}
+	return nil
+}
+
+func (s *memoryPseudonymStore) CheckAndIncrement(_ context.Context, pub ed25519.PublicKey, epoch int64, limit uint32, now time.Time) error {
+	if len(pub) != ed25519.PublicKeySize {
+		return ErrPseudonymInvalid
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rec, ok := s.records[string(pub)]
+	if !ok {
+		return ErrPseudonymInvalid
+	}
+	if !rec.expires.After(now) {
+		return ErrPseudonymExpired
+	}
+	if rec.lastEpoch != epoch {
+		rec.lastEpoch = epoch
+		rec.tokensThisEpoch = 0
+	}
+	if rec.tokensThisEpoch >= limit {
+		return ErrRateLimited
+	}
+	rec.tokensThisEpoch++
+	return nil
+}
+
+func (s *memoryPseudonymStore) DeleteExpired(_ context.Context, before time.Time) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	deleted := 0
+	for key, rec := range s.records {
+		if !rec.expires.After(before) {
+			delete(s.records, key)
+			deleted++
+		}
+	}
+	return deleted, nil
+}
+
+func (s *memoryPseudonymStore) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records = nil
+	return nil
+}

--- a/server/internal/anonauth/pseudonym_memory_test.go
+++ b/server/internal/anonauth/pseudonym_memory_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package anonauth_test
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/WissCore/moldchat/server/internal/anonauth"
+)
+
+func freshKey(tb testing.TB) ed25519.PublicKey {
+	tb.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		tb.Fatalf("ed25519: %v", err)
+	}
+	return pub
+}
+
+func TestMemoryStore_RegisterDuplicateRejected(t *testing.T) {
+	t.Parallel()
+	store := anonauth.NewMemoryPseudonymStore()
+	pub := freshKey(t)
+	now := time.Now()
+	if err := store.Register(context.Background(), pub, now, now.Add(time.Hour)); err != nil {
+		t.Fatalf("first register: %v", err)
+	}
+	err := store.Register(context.Background(), pub, now, now.Add(time.Hour))
+	if !errors.Is(err, anonauth.ErrPseudonymExists) {
+		t.Fatalf("expected ErrPseudonymExists, got %v", err)
+	}
+}
+
+func TestMemoryStore_CheckAndIncrement_Limit(t *testing.T) {
+	t.Parallel()
+	store := anonauth.NewMemoryPseudonymStore()
+	pub := freshKey(t)
+	now := time.Now()
+	_ = store.Register(context.Background(), pub, now, now.Add(time.Hour))
+	for i := uint32(0); i < 3; i++ {
+		if err := store.CheckAndIncrement(context.Background(), pub, 42, 3, now); err != nil {
+			t.Fatalf("increment %d: %v", i, err)
+		}
+	}
+	if err := store.CheckAndIncrement(context.Background(), pub, 42, 3, now); !errors.Is(err, anonauth.ErrRateLimited) {
+		t.Fatalf("expected ErrRateLimited, got %v", err)
+	}
+}
+
+func TestMemoryStore_CheckAndIncrement_EpochReset(t *testing.T) {
+	t.Parallel()
+	store := anonauth.NewMemoryPseudonymStore()
+	pub := freshKey(t)
+	now := time.Now()
+	_ = store.Register(context.Background(), pub, now, now.Add(2*time.Hour))
+	for i := 0; i < 5; i++ {
+		_ = store.CheckAndIncrement(context.Background(), pub, 42, 5, now)
+	}
+	if err := store.CheckAndIncrement(context.Background(), pub, 43, 5, now); err != nil {
+		t.Fatalf("expected fresh quota in new epoch, got %v", err)
+	}
+}
+
+func TestMemoryStore_CheckAndIncrement_Expired(t *testing.T) {
+	t.Parallel()
+	store := anonauth.NewMemoryPseudonymStore()
+	pub := freshKey(t)
+	now := time.Now()
+	_ = store.Register(context.Background(), pub, now.Add(-2*time.Hour), now.Add(-time.Hour))
+	err := store.CheckAndIncrement(context.Background(), pub, 1, 5, now)
+	if !errors.Is(err, anonauth.ErrPseudonymExpired) {
+		t.Fatalf("expected ErrPseudonymExpired, got %v", err)
+	}
+}
+
+func TestMemoryStore_DeleteExpired(t *testing.T) {
+	t.Parallel()
+	store := anonauth.NewMemoryPseudonymStore()
+	now := time.Now()
+	live := freshKey(t)
+	dead := freshKey(t)
+	_ = store.Register(context.Background(), live, now, now.Add(time.Hour))
+	_ = store.Register(context.Background(), dead, now.Add(-2*time.Hour), now.Add(-time.Hour))
+	deleted, err := store.DeleteExpired(context.Background(), now)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("expected 1 deletion, got %d", deleted)
+	}
+	// The live record must still authorise increments after the cleanup.
+	if err := store.CheckAndIncrement(context.Background(), live, 0, 1, now); err != nil {
+		t.Fatalf("live record should remain usable: %v", err)
+	}
+}
+
+func TestMemoryStore_CheckAndIncrement_RaceBoundaryRespected(t *testing.T) {
+	t.Parallel()
+	store := anonauth.NewMemoryPseudonymStore()
+	pub := freshKey(t)
+	now := time.Now()
+	_ = store.Register(context.Background(), pub, now, now.Add(time.Hour))
+
+	const limit = 100
+	const goroutines = 32
+	var ok atomic.Int64
+	var rejected atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < limit; j++ {
+				err := store.CheckAndIncrement(context.Background(), pub, 1, limit, now)
+				switch {
+				case err == nil:
+					ok.Add(1)
+				case errors.Is(err, anonauth.ErrRateLimited):
+					rejected.Add(1)
+				default:
+					t.Errorf("unexpected: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if ok.Load() != int64(limit) {
+		t.Fatalf("expected exactly %d successful increments, got %d", limit, ok.Load())
+	}
+	if rejected.Load() == 0 {
+		t.Fatalf("expected some rate-limit rejections under contention")
+	}
+}

--- a/server/internal/anonauth/roundtrip_test.go
+++ b/server/internal/anonauth/roundtrip_test.go
@@ -1,0 +1,365 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package anonauth_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/WissCore/moldchat/server/internal/anonauth"
+	"github.com/cloudflare/circl/group"
+	"github.com/cloudflare/circl/oprf"
+	dleqpkg "github.com/cloudflare/circl/zk/dleq"
+)
+
+// fixedClock returns a closure that always reports t. Tests advance
+// the clock by replacing the closure rather than mutating shared
+// state, which keeps each step explicit.
+func fixedClock(t time.Time) func() time.Time { return func() time.Time { return t } }
+
+// newTestStack constructs an issuer + verifier pair sharing a fresh
+// in-memory pseudonym store and a deterministic clock. The returned
+// IssuerKey lets tests build the matching POPRF client.
+func newTestStack(tb testing.TB, now time.Time, cfg anonauth.IssuerConfig) (*anonauth.Issuer, *anonauth.Verifier, *anonauth.IssuerKey) {
+	tb.Helper()
+	seed := make([]byte, 32)
+	if _, err := rand.Read(seed); err != nil {
+		tb.Fatalf("seed: %v", err)
+	}
+	key, err := anonauth.DeriveIssuerKey(seed)
+	if err != nil {
+		tb.Fatalf("derive: %v", err)
+	}
+	iss, err := anonauth.NewIssuer(cfg, key, anonauth.NewMemoryPseudonymStore())
+	if err != nil {
+		tb.Fatalf("issuer: %v", err)
+	}
+	ver, err := anonauth.NewVerifier(anonauth.VerifierConfig{Epoch: cfg.Epoch}, key)
+	if err != nil {
+		tb.Fatalf("verifier: %v", err)
+	}
+	iss.SetClockForTest(fixedClock(now))
+	ver.SetClockForTest(fixedClock(now))
+	return iss, ver, key
+}
+
+// registerPseudonym solves a hashcash and registers a fresh
+// pseudonym. Returns the pseudonym key pair.
+func registerPseudonym(tb testing.TB, iss *anonauth.Issuer) (ed25519.PublicKey, ed25519.PrivateKey) {
+	tb.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		tb.Fatalf("ed25519: %v", err)
+	}
+	ch, err := iss.PoWChallenge()
+	if err != nil {
+		tb.Fatalf("challenge: %v", err)
+	}
+	nonce := solvePoW(tb, ch.Bytes, ch.DifficultyBits)
+	if err := iss.RegisterPseudonym(context.Background(), pub, ch.Bytes, nonce); err != nil {
+		tb.Fatalf("register: %v", err)
+	}
+	return pub, priv
+}
+
+// issueAndFinalize runs the full client flow: blind one input, send
+// to issuer, finalize the response into the canonical (input, mac).
+// The DLEQ proof is verified inside Finalize so a bug in proof
+// generation would surface here, not silently downstream.
+func issueAndFinalize(tb testing.TB, iss *anonauth.Issuer, key *anonauth.IssuerKey, pub ed25519.PublicKey, priv ed25519.PrivateKey, epoch int64) (input, mac []byte) {
+	tb.Helper()
+	suite := key.Suite()
+	pubKey, err := key.PublicKey()
+	if err != nil {
+		tb.Fatalf("issuer pub: %v", err)
+	}
+	parsedPub := new(oprf.PublicKey)
+	if parseErr := parsedPub.UnmarshalBinary(suite, pubKey); parseErr != nil {
+		tb.Fatalf("parse pub: %v", parseErr)
+	}
+	client := oprf.NewPartialObliviousClient(suite, parsedPub)
+
+	input = make([]byte, 16)
+	if _, randErr := rand.Read(input); randErr != nil {
+		tb.Fatalf("input: %v", randErr)
+	}
+	finData, evalReq, err := client.Blind([][]byte{input})
+	if err != nil {
+		tb.Fatalf("blind: %v", err)
+	}
+	blindedBytes, err := evalReq.Elements[0].MarshalBinaryCompress()
+	if err != nil {
+		tb.Fatalf("marshal blinded: %v", err)
+	}
+
+	signed := anonauth.CanonicalIssuancePayloadForTest(epoch, blindedBytes)
+	sig := ed25519.Sign(priv, signed)
+	resp, err := iss.IssueToken(context.Background(), anonauth.IssuanceRequest{
+		Blinded:      blindedBytes,
+		PseudonymPub: pub,
+		Signature:    sig,
+		Epoch:        epoch,
+	})
+	if err != nil {
+		tb.Fatalf("issue: %v", err)
+	}
+
+	evalElement := suite.Group().NewElement()
+	if elemErr := evalElement.UnmarshalBinary(resp.Evaluation); elemErr != nil {
+		tb.Fatalf("unmarshal evaluation: %v", elemErr)
+	}
+	proof := &dleqpkg.Proof{}
+	full := append(append([]byte{}, resp.ProofC...), resp.ProofS...)
+	if proofErr := proof.UnmarshalBinary(suite.Group(), full); proofErr != nil {
+		tb.Fatalf("unmarshal proof: %v", proofErr)
+	}
+	evaluation := &oprf.Evaluation{
+		Elements: []group.Element{evalElement},
+		Proof:    proof,
+	}
+
+	outputs, err := client.Finalize(finData, evaluation, anonauth.EpochInfo(epoch))
+	if err != nil {
+		tb.Fatalf("finalize: %v", err)
+	}
+	if len(outputs) != 1 {
+		tb.Fatalf("unexpected output arity %d", len(outputs))
+	}
+	return input, outputs[0]
+}
+
+func TestRoundtrip_HappyPath(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	iss, ver, key := newTestStack(t, now, anonauth.IssuerConfig{
+		Epoch:             time.Hour,
+		PseudonymTTL:      24 * time.Hour,
+		TokensPerEpoch:    3,
+		PoWDifficultyBits: 4,
+	})
+	pub, priv := registerPseudonym(t, iss)
+	input, mac := issueAndFinalize(t, iss, key, pub, priv, iss.CurrentEpoch(now))
+	if err := ver.Verify(input, mac); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+}
+
+func TestRoundtrip_ReplayRejected(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	iss, ver, key := newTestStack(t, now, anonauth.IssuerConfig{
+		Epoch:             time.Hour,
+		PseudonymTTL:      24 * time.Hour,
+		TokensPerEpoch:    5,
+		PoWDifficultyBits: 4,
+	})
+	pub, priv := registerPseudonym(t, iss)
+	input, mac := issueAndFinalize(t, iss, key, pub, priv, iss.CurrentEpoch(now))
+	if err := ver.Verify(input, mac); err != nil {
+		t.Fatalf("first verify: %v", err)
+	}
+	if err := ver.Verify(input, mac); !errors.Is(err, anonauth.ErrTokenReplayed) {
+		t.Fatalf("expected ErrTokenReplayed on replay, got %v", err)
+	}
+}
+
+func TestRoundtrip_TamperedMACRejected(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	iss, ver, key := newTestStack(t, now, anonauth.IssuerConfig{
+		Epoch:             time.Hour,
+		PseudonymTTL:      24 * time.Hour,
+		TokensPerEpoch:    5,
+		PoWDifficultyBits: 4,
+	})
+	pub, priv := registerPseudonym(t, iss)
+	input, mac := issueAndFinalize(t, iss, key, pub, priv, iss.CurrentEpoch(now))
+	tampered := append([]byte{}, mac...)
+	tampered[0] ^= 0x01
+	if err := ver.Verify(input, tampered); !errors.Is(err, anonauth.ErrTokenInvalid) {
+		t.Fatalf("expected ErrTokenInvalid on tamper, got %v", err)
+	}
+	// The original mac must still verify cleanly: tamper attempts
+	// must not consume the spent-set slot.
+	if err := ver.Verify(input, mac); err != nil {
+		t.Fatalf("original verify after tamper: %v", err)
+	}
+}
+
+func TestRoundtrip_CrossEpochRejected(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	iss, ver, key := newTestStack(t, now, anonauth.IssuerConfig{
+		Epoch:             time.Hour,
+		PseudonymTTL:      24 * time.Hour,
+		TokensPerEpoch:    5,
+		PoWDifficultyBits: 4,
+	})
+	pub, priv := registerPseudonym(t, iss)
+	input, mac := issueAndFinalize(t, iss, key, pub, priv, iss.CurrentEpoch(now))
+
+	// Advance both clocks past the grace window (two full epochs).
+	future := now.Add(3 * time.Hour)
+	iss.SetClockForTest(fixedClock(future))
+	ver.SetClockForTest(fixedClock(future))
+
+	if err := ver.Verify(input, mac); !errors.Is(err, anonauth.ErrTokenInvalid) {
+		t.Fatalf("expected ErrTokenInvalid past grace, got %v", err)
+	}
+}
+
+func TestRoundtrip_GraceEpochAccepted(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	iss, ver, key := newTestStack(t, now, anonauth.IssuerConfig{
+		Epoch:             time.Hour,
+		PseudonymTTL:      24 * time.Hour,
+		TokensPerEpoch:    5,
+		PoWDifficultyBits: 4,
+	})
+	pub, priv := registerPseudonym(t, iss)
+	input, mac := issueAndFinalize(t, iss, key, pub, priv, iss.CurrentEpoch(now))
+
+	// Advance verifier clock by one epoch so the token's epoch is
+	// now the immediately preceding one. The grace window must
+	// still accept it.
+	graced := now.Add(time.Hour + time.Minute)
+	ver.SetClockForTest(fixedClock(graced))
+	if err := ver.Verify(input, mac); err != nil {
+		t.Fatalf("expected acceptance in grace epoch, got %v", err)
+	}
+}
+
+func TestRoundtrip_RateLimit(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	iss, _, key := newTestStack(t, now, anonauth.IssuerConfig{
+		Epoch:             time.Hour,
+		PseudonymTTL:      24 * time.Hour,
+		TokensPerEpoch:    2,
+		PoWDifficultyBits: 4,
+	})
+	pub, priv := registerPseudonym(t, iss)
+	for i := 0; i < 2; i++ {
+		issueAndFinalize(t, iss, key, pub, priv, iss.CurrentEpoch(now))
+	}
+
+	suite := key.Suite()
+	pubKey, _ := key.PublicKey()
+	parsedPub := new(oprf.PublicKey)
+	_ = parsedPub.UnmarshalBinary(suite, pubKey)
+	client := oprf.NewPartialObliviousClient(suite, parsedPub)
+	_, evalReq, _ := client.Blind([][]byte{[]byte("third")})
+	blinded, _ := evalReq.Elements[0].MarshalBinaryCompress()
+	signed := anonauth.CanonicalIssuancePayloadForTest(iss.CurrentEpoch(now), blinded)
+	sig := ed25519.Sign(priv, signed)
+	_, err := iss.IssueToken(context.Background(), anonauth.IssuanceRequest{
+		Blinded:      blinded,
+		PseudonymPub: pub,
+		Signature:    sig,
+		Epoch:        iss.CurrentEpoch(now),
+	})
+	if !errors.Is(err, anonauth.ErrRateLimited) {
+		t.Fatalf("expected ErrRateLimited, got %v", err)
+	}
+
+	// Advancing one epoch resets the counter.
+	next := now.Add(time.Hour)
+	iss.SetClockForTest(fixedClock(next))
+	signed2 := anonauth.CanonicalIssuancePayloadForTest(iss.CurrentEpoch(next), blinded)
+	sig2 := ed25519.Sign(priv, signed2)
+	if _, err := iss.IssueToken(context.Background(), anonauth.IssuanceRequest{
+		Blinded:      blinded,
+		PseudonymPub: pub,
+		Signature:    sig2,
+		Epoch:        iss.CurrentEpoch(next),
+	}); err != nil {
+		t.Fatalf("expected fresh quota in next epoch, got %v", err)
+	}
+}
+
+func TestRoundtrip_ConcurrentIssueAndVerify(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	iss, ver, key := newTestStack(t, now, anonauth.IssuerConfig{
+		Epoch:             time.Hour,
+		PseudonymTTL:      24 * time.Hour,
+		TokensPerEpoch:    1000,
+		PoWDifficultyBits: 4,
+	})
+	pub, priv := registerPseudonym(t, iss)
+
+	const workers = 8
+	const perWorker = 25
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				input, mac := issueAndFinalize(t, iss, key, pub, priv, iss.CurrentEpoch(now))
+				if err := ver.Verify(input, mac); err != nil {
+					t.Errorf("verify in worker: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	got := ver.SpentSetSizeForTest()
+	if got != workers*perWorker {
+		t.Fatalf("spent set size = %d, want %d", got, workers*perWorker)
+	}
+}
+
+func TestRoundtrip_ForgedSignatureRejected(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	iss, _, key := newTestStack(t, now, anonauth.IssuerConfig{
+		Epoch:             time.Hour,
+		PseudonymTTL:      24 * time.Hour,
+		TokensPerEpoch:    5,
+		PoWDifficultyBits: 4,
+	})
+	pub, _ := registerPseudonym(t, iss)
+	_, attacker, _ := ed25519.GenerateKey(rand.Reader)
+
+	suite := key.Suite()
+	pubKey, _ := key.PublicKey()
+	parsedPub := new(oprf.PublicKey)
+	_ = parsedPub.UnmarshalBinary(suite, pubKey)
+	client := oprf.NewPartialObliviousClient(suite, parsedPub)
+	_, evalReq, _ := client.Blind([][]byte{[]byte("forged")})
+	blinded, _ := evalReq.Elements[0].MarshalBinaryCompress()
+	signed := anonauth.CanonicalIssuancePayloadForTest(iss.CurrentEpoch(now), blinded)
+	sig := ed25519.Sign(attacker, signed)
+	_, err := iss.IssueToken(context.Background(), anonauth.IssuanceRequest{
+		Blinded:      blinded,
+		PseudonymPub: pub,
+		Signature:    sig,
+		Epoch:        iss.CurrentEpoch(now),
+	})
+	if !errors.Is(err, anonauth.ErrPseudonymInvalid) {
+		t.Fatalf("expected ErrPseudonymInvalid for forged signature, got %v", err)
+	}
+}
+
+func TestCanonicalPayload_LayoutStable(t *testing.T) {
+	t.Parallel()
+	const tag = "moldd-anonauth-issue-v1"
+	const epoch int64 = 0x1EADBEEF12345678
+	blinded := []byte{0x01, 0x02, 0x03}
+	want := append(append(append(append(append([]byte{}, tag...), 0), anonauth.EpochInfo(epoch)...), 0), blinded...)
+	got := anonauth.CanonicalIssuancePayloadForTest(epoch, blinded)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("canonical payload changed: got %x want %x", got, want)
+	}
+}

--- a/server/internal/anonauth/spent.go
+++ b/server/internal/anonauth/spent.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package anonauth
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+// spentSet tracks redeemed token MACs so a presented token cannot be
+// replayed within its epoch (or the one-epoch grace window). Implemented
+// as a bounded LRU keyed by the truncated MAC; the truncation is
+// safe because the MAC is a 64-byte SHA-512 output and the first 16
+// bytes carry far more collision resistance than the issuance rate
+// can plausibly exhaust.
+//
+// Eviction policy: oldest entry first when the cap is hit. That is
+// safe because tokens carry an epoch in their POPRF info — a token
+// older than the grace window will fail FullEvaluate before its mac
+// is ever consulted, so an evicted-but-still-valid mac is impossible.
+type spentSet struct {
+	mu       sync.Mutex
+	capacity int
+	order    *list.List // front = MRU, back = LRU
+	index    map[[spentKeyBytes]byte]*list.Element
+}
+
+const (
+	// spentKeyBytes is the truncation length of the stored mac. 16
+	// bytes (128 bits) of SHA-512 output yields a collision
+	// probability well below 2^-100 at any plausible token volume,
+	// which is more than enough for replay protection.
+	spentKeyBytes = 16
+
+	// DefaultSpentSetCapacity bounds the in-memory spent-set. The
+	// default supports several hundred thousand redemptions per
+	// epoch — well above what a single per-pseudonym counter can
+	// authorise — without growing past a few tens of MiB.
+	DefaultSpentSetCapacity = 1_000_000
+)
+
+type spentEntry struct {
+	key       [spentKeyBytes]byte
+	expiresAt time.Time
+}
+
+// newSpentSet returns a fresh spent set with the supplied capacity.
+// Capacity ≤ 0 is rejected at construction so callers cannot
+// accidentally disable replay protection by passing the zero value.
+func newSpentSet(capacity int) *spentSet {
+	if capacity <= 0 {
+		capacity = DefaultSpentSetCapacity
+	}
+	return &spentSet{
+		capacity: capacity,
+		order:    list.New(),
+		index:    make(map[[spentKeyBytes]byte]*list.Element),
+	}
+}
+
+// markIfFresh records mac as spent unless it is already in the set
+// and its recorded expiry is still in the future. Returns true on
+// fresh insertion, false when the mac was already present and unexpired
+// (i.e. a replay). An entry whose expiry has lapsed is treated as
+// fresh: the old record is overwritten and the call returns true,
+// which lets the operator change the epoch boundary without flushing
+// state explicitly.
+func (s *spentSet) markIfFresh(mac []byte, expiresAt time.Time, now time.Time) bool {
+	if len(mac) < spentKeyBytes {
+		return false
+	}
+	var key [spentKeyBytes]byte
+	copy(key[:], mac[:spentKeyBytes])
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if elem, ok := s.index[key]; ok {
+		entry := elem.Value.(*spentEntry)
+		if entry.expiresAt.After(now) {
+			return false
+		}
+		// Stale — replace in place.
+		entry.expiresAt = expiresAt
+		s.order.MoveToFront(elem)
+		return true
+	}
+
+	if len(s.index) >= s.capacity {
+		oldest := s.order.Back()
+		if oldest != nil {
+			oldEntry := oldest.Value.(*spentEntry)
+			delete(s.index, oldEntry.key)
+			s.order.Remove(oldest)
+		}
+	}
+	entry := &spentEntry{key: key, expiresAt: expiresAt}
+	elem := s.order.PushFront(entry)
+	s.index[key] = elem
+	return true
+}
+
+// size returns the current number of tracked entries; used by tests
+// only, not exported on the issuance path.
+func (s *spentSet) size() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.index)
+}

--- a/server/internal/anonauth/spent_test.go
+++ b/server/internal/anonauth/spent_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package anonauth_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/WissCore/moldchat/server/internal/anonauth"
+)
+
+// The spent-set is package-private. The tests here exercise it
+// through the only public consumer (Verifier.Verify) which gives the
+// same coverage without reaching into unexported state. Each test
+// sets up a verifier with a tiny SpentSetCapacity to make eviction
+// observable in a few requests.
+
+// newVerifier mirrors the helper in roundtrip_test.go but inlines
+// the seed/key boilerplate so this file is self-contained.
+func newVerifierWithCapacity(tb testing.TB, capacity int, now time.Time) (*anonauth.Verifier, *anonauth.IssuerKey) {
+	tb.Helper()
+	seed := make([]byte, 32)
+	if _, err := rand.Read(seed); err != nil {
+		tb.Fatalf("seed: %v", err)
+	}
+	key, err := anonauth.DeriveIssuerKey(seed)
+	if err != nil {
+		tb.Fatalf("derive: %v", err)
+	}
+	ver, err := anonauth.NewVerifier(anonauth.VerifierConfig{
+		Epoch:            time.Hour,
+		SpentSetCapacity: capacity,
+	}, key)
+	if err != nil {
+		tb.Fatalf("verifier: %v", err)
+	}
+	ver.SetClockForTest(func() time.Time { return now })
+	return ver, key
+}
+
+// finalizeOne constructs a (input, mac) pair for the supplied epoch
+// by running FullEvaluate on a fresh random input. This bypasses the
+// blinded-protocol path used in roundtrip_test.go because the
+// spent-set tests do not need blinded inputs — they only need
+// distinct, verifier-acceptable tokens.
+func finalizeOne(tb testing.TB, key *anonauth.IssuerKey, epoch int64) (input, mac []byte) {
+	tb.Helper()
+	input = make([]byte, 16)
+	if _, err := rand.Read(input); err != nil {
+		tb.Fatalf("input: %v", err)
+	}
+	out, err := anonauth.FullEvaluateForTest(key, input, epoch)
+	if err != nil {
+		tb.Fatalf("full evaluate: %v", err)
+	}
+	return input, out
+}
+
+func TestSpentSet_FreshThenReplay(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	ver, key := newVerifierWithCapacity(t, 16, now)
+	input, mac := finalizeOne(t, key, ver.CurrentEpoch(now))
+
+	if err := ver.Verify(input, mac); err != nil {
+		t.Fatalf("first verify: %v", err)
+	}
+	if err := ver.Verify(input, mac); !errors.Is(err, anonauth.ErrTokenReplayed) {
+		t.Fatalf("expected ErrTokenReplayed on replay, got %v", err)
+	}
+}
+
+func TestSpentSet_LRUEvictionAllowsReuseAfterEviction(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	const capacity = 2
+	ver, key := newVerifierWithCapacity(t, capacity, now)
+
+	tokens := make([][2][]byte, 3)
+	for i := range tokens {
+		input, mac := finalizeOne(t, key, ver.CurrentEpoch(now))
+		tokens[i] = [2][]byte{input, mac}
+		if err := ver.Verify(input, mac); err != nil {
+			t.Fatalf("verify %d: %v", i, err)
+		}
+	}
+	if got := ver.SpentSetSizeForTest(); got != capacity {
+		t.Fatalf("size after eviction = %d, want %d", got, capacity)
+	}
+	// The first token was the LRU and must have been evicted, so a
+	// replay attempt is no longer detected. This is intentional:
+	// once a token is evicted from the spent-set the operator
+	// accepts that the per-pseudonym counter (issuance side) is the
+	// only remaining defence. Document the behaviour by asserting
+	// the evicted token re-verifies cleanly.
+	if err := ver.Verify(tokens[0][0], tokens[0][1]); err != nil {
+		t.Fatalf("evicted token should re-verify cleanly, got %v", err)
+	}
+}
+
+func TestSpentSet_RejectsTamperedTokenWithoutConsumingSlot(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	ver, key := newVerifierWithCapacity(t, 16, now)
+	input, mac := finalizeOne(t, key, ver.CurrentEpoch(now))
+
+	tampered := append([]byte{}, mac...)
+	tampered[0] ^= 0x01
+	if err := ver.Verify(input, tampered); !errors.Is(err, anonauth.ErrTokenInvalid) {
+		t.Fatalf("expected ErrTokenInvalid on tampered mac, got %v", err)
+	}
+	// The original mac must still verify because the failed attempt
+	// never reached the spent-set markIfFresh path.
+	if err := ver.Verify(input, mac); err != nil {
+		t.Fatalf("original mac after tamper: %v", err)
+	}
+}
+
+func TestSpentSet_ZeroLengthMacRejected(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	ver, _ := newVerifierWithCapacity(t, 16, now)
+	if err := ver.Verify(bytes.Repeat([]byte{0x01}, 16), nil); !errors.Is(err, anonauth.ErrTokenInvalid) {
+		t.Fatalf("expected ErrTokenInvalid for empty mac, got %v", err)
+	}
+}

--- a/server/internal/anonauth/sqlitestore/store.go
+++ b/server/internal/anonauth/sqlitestore/store.go
@@ -1,0 +1,258 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package sqlitestore is the SQLCipher-backed implementation of
+// anonauth.PseudonymStore. The pseudonym database lives in its own
+// encrypted file with a key derived from the deployment's master seed
+// via a dedicated HKDF info string, so the queue-storage seed and
+// this file's seed never share derivation paths even when they share
+// the same underlying secret.
+package sqlitestore
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/WissCore/moldchat/server/internal/anonauth"
+	sqlcipher "github.com/mutecomm/go-sqlcipher/v4"
+	"golang.org/x/crypto/hkdf"
+)
+
+const (
+	dbFilename       = "pseudonyms.db"
+	dataDirPerm      = 0o700
+	maxOpenConns     = 1 // SQLite serialises writers; one conn avoids SQLITE_BUSY
+	pseudonymKeyInfo = "moldd-anonauth-pseudonym-db-key-v1"
+	masterSeedBytes  = 32
+)
+
+// cipherDriver is the package-shared SQLCipher driver instance, kept
+// at package scope so its one-time initialisation (loadable
+// extensions, etc.) does not run per Connect.
+var cipherDriver = &sqlcipher.SQLiteDriver{}
+
+// cipherConnector mirrors the queue-store cipherConnector pattern
+// closely on purpose: same key derivation discipline (compute the
+// hex key inside Connect, never store it on the struct), same
+// PRAGMA temp_store hardening, same WAL toggle.
+type cipherConnector struct {
+	dsn       string
+	deriveKey func() (string, error)
+}
+
+func (c *cipherConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	hexKey, err := c.deriveKey()
+	if err != nil {
+		return nil, err
+	}
+	conn, err := cipherDriver.Open(c.dsn + "?_pragma_key=x'" + hexKey + "'")
+	if err != nil {
+		return nil, err
+	}
+	execer, ok := conn.(driver.ExecerContext)
+	if !ok {
+		_ = conn.Close()
+		return nil, errors.New("sqlite driver does not implement ExecerContext")
+	}
+	if _, execErr := execer.ExecContext(ctx, "PRAGMA temp_store = MEMORY", nil); execErr != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("set pragma temp_store: %w", execErr)
+	}
+	if _, execErr := execer.ExecContext(ctx, "PRAGMA journal_mode = WAL", nil); execErr != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("set pragma journal_mode: %w", execErr)
+	}
+	return conn, nil
+}
+
+func (c *cipherConnector) Driver() driver.Driver { return cipherDriver }
+
+// Store is the SQLCipher-backed pseudonym store.
+type Store struct {
+	db   *sql.DB
+	mu   sync.Mutex // serialises CheckAndIncrement updates against the same row
+	seed [masterSeedBytes]byte
+}
+
+// New opens (or creates) the pseudonym database under dataDir. dataDir
+// is created with 0700 permissions if it does not exist; the database
+// file is encrypted with a key derived from seed via the package's
+// dedicated HKDF info string.
+func New(seed [masterSeedBytes]byte, dataDir string) (*Store, error) {
+	abs, err := filepath.Abs(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve dataDir: %w", err)
+	}
+	if mkdirErr := os.MkdirAll(abs, dataDirPerm); mkdirErr != nil {
+		return nil, fmt.Errorf("create dataDir: %w", mkdirErr)
+	}
+	dbPath := filepath.Join(abs, dbFilename)
+	conn := &cipherConnector{
+		dsn: "file:" + dbPath,
+		deriveKey: func() (string, error) {
+			return deriveHexKey(seed[:])
+		},
+	}
+	db := sql.OpenDB(conn)
+	db.SetMaxOpenConns(maxOpenConns)
+	if pingErr := db.Ping(); pingErr != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("ping db: %w", pingErr)
+	}
+	if _, schemaErr := db.Exec(schema); schemaErr != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("init schema: %w", schemaErr)
+	}
+	return &Store{db: db, seed: seed}, nil
+}
+
+// Close releases the underlying database handle.
+func (s *Store) Close() error {
+	return s.db.Close()
+}
+
+const schema = `
+CREATE TABLE IF NOT EXISTS pseudonyms (
+	pubkey            BLOB    NOT NULL,
+	created_at        INTEGER NOT NULL,
+	expires_at        INTEGER NOT NULL,
+	last_epoch        INTEGER NOT NULL DEFAULT 0,
+	tokens_in_epoch   INTEGER NOT NULL DEFAULT 0,
+	PRIMARY KEY (pubkey)
+);
+CREATE INDEX IF NOT EXISTS idx_pseudonyms_expires_at ON pseudonyms(expires_at);
+`
+
+// Register persists a pseudonym record. Returns
+// anonauth.ErrPseudonymExists if the pubkey is already registered.
+func (s *Store) Register(ctx context.Context, pub ed25519.PublicKey, created, expires time.Time) error {
+	if len(pub) != ed25519.PublicKeySize {
+		return anonauth.ErrPseudonymInvalid
+	}
+	res, err := s.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO pseudonyms(pubkey, created_at, expires_at, last_epoch, tokens_in_epoch) VALUES (?, ?, ?, 0, 0)`,
+		[]byte(pub), created.UnixNano(), expires.UnixNano(),
+	)
+	if err != nil {
+		return fmt.Errorf("insert pseudonym: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if affected == 0 {
+		return anonauth.ErrPseudonymExists
+	}
+	return nil
+}
+
+// CheckAndIncrement runs the per-epoch counter logic atomically. The
+// SELECT-then-UPDATE happens inside a transaction; the package mutex
+// guards against the SQLITE_BUSY-free race between two writers
+// reaching the same row at the same instant.
+//
+// The sequence:
+//
+//  1. SELECT the current row inside a transaction.
+//  2. If expires_at <= now, abort with ErrPseudonymExpired.
+//  3. If last_epoch != epoch, the row's counter is stale and we
+//     treat the current value as 0. Otherwise we use it as is.
+//  4. If the (possibly reset) counter is already at the limit, abort
+//     with ErrRateLimited.
+//  5. UPDATE the row to the new (epoch, counter+1) and commit.
+func (s *Store) CheckAndIncrement(ctx context.Context, pub ed25519.PublicKey, epoch int64, limit uint32, now time.Time) error {
+	if len(pub) != ed25519.PublicKeySize {
+		return anonauth.ErrPseudonymInvalid
+	}
+	if epoch < 0 {
+		return fmt.Errorf("anonauth/sqlitestore: negative epoch %d", epoch)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var (
+		expiresNs int64
+		lastEpoch int64
+		tokensCur int64
+	)
+	row := tx.QueryRowContext(ctx,
+		`SELECT expires_at, last_epoch, tokens_in_epoch FROM pseudonyms WHERE pubkey = ?`,
+		[]byte(pub),
+	)
+	if scanErr := row.Scan(&expiresNs, &lastEpoch, &tokensCur); scanErr != nil {
+		if errors.Is(scanErr, sql.ErrNoRows) {
+			return anonauth.ErrPseudonymInvalid
+		}
+		return fmt.Errorf("select pseudonym: %w", scanErr)
+	}
+	if expiresNs <= now.UnixNano() {
+		return anonauth.ErrPseudonymExpired
+	}
+	if lastEpoch < 0 || tokensCur < 0 {
+		return fmt.Errorf("pseudonym counter out of range: epoch=%d tokens=%d", lastEpoch, tokensCur)
+	}
+
+	current := tokensCur
+	if lastEpoch != epoch {
+		current = 0
+	}
+	if current >= int64(limit) {
+		return anonauth.ErrRateLimited
+	}
+	if _, execErr := tx.ExecContext(ctx,
+		`UPDATE pseudonyms SET last_epoch = ?, tokens_in_epoch = ? WHERE pubkey = ?`,
+		epoch, current+1, []byte(pub),
+	); execErr != nil {
+		return fmt.Errorf("update counter: %w", execErr)
+	}
+	if commitErr := tx.Commit(); commitErr != nil {
+		return fmt.Errorf("commit: %w", commitErr)
+	}
+	return nil
+}
+
+// DeleteExpired removes records whose expiry is at or before before.
+func (s *Store) DeleteExpired(ctx context.Context, before time.Time) (int, error) {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM pseudonyms WHERE expires_at <= ?`, before.UnixNano())
+	if err != nil {
+		return 0, fmt.Errorf("delete expired: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(affected), nil
+}
+
+// deriveHexKey runs HKDF-SHA-256 over the seed and the package's
+// dedicated info string and returns the resulting 32 bytes hex-
+// encoded, ready to drop into the SQLCipher PRAGMA key.
+func deriveHexKey(seed []byte) (string, error) {
+	r := hkdf.New(sha256.New, seed, nil, []byte(pseudonymKeyInfo))
+	out := make([]byte, masterSeedBytes)
+	if _, err := io.ReadFull(r, out); err != nil {
+		return "", fmt.Errorf("hkdf read: %w", err)
+	}
+	return hex.EncodeToString(out), nil
+}
+
+var _ anonauth.PseudonymStore = (*Store)(nil)

--- a/server/internal/anonauth/sqlitestore/store_test.go
+++ b/server/internal/anonauth/sqlitestore/store_test.go
@@ -1,0 +1,186 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sqlitestore_test
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/WissCore/moldchat/server/internal/anonauth"
+	"github.com/WissCore/moldchat/server/internal/anonauth/sqlitestore"
+)
+
+func newStore(tb testing.TB) *sqlitestore.Store {
+	tb.Helper()
+	var seed [32]byte
+	if _, err := rand.Read(seed[:]); err != nil {
+		tb.Fatalf("seed: %v", err)
+	}
+	store, err := sqlitestore.New(seed, tb.TempDir())
+	if err != nil {
+		tb.Fatalf("new: %v", err)
+	}
+	tb.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func freshKey(tb testing.TB) ed25519.PublicKey {
+	tb.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		tb.Fatalf("ed25519: %v", err)
+	}
+	return pub
+}
+
+func TestStore_DuplicateRegisterRejected(t *testing.T) {
+	t.Parallel()
+	store := newStore(t)
+	pub := freshKey(t)
+	now := time.Now()
+	if err := store.Register(context.Background(), pub, now, now.Add(time.Hour)); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	err := store.Register(context.Background(), pub, now, now.Add(time.Hour))
+	if !errors.Is(err, anonauth.ErrPseudonymExists) {
+		t.Fatalf("expected ErrPseudonymExists, got %v", err)
+	}
+}
+
+func TestStore_CheckAndIncrement(t *testing.T) {
+	t.Parallel()
+	store := newStore(t)
+	pub := freshKey(t)
+	now := time.Now()
+	_ = store.Register(context.Background(), pub, now, now.Add(time.Hour))
+
+	for i := uint32(0); i < 3; i++ {
+		if err := store.CheckAndIncrement(context.Background(), pub, 99, 3, now); err != nil {
+			t.Fatalf("inc %d: %v", i, err)
+		}
+	}
+	if err := store.CheckAndIncrement(context.Background(), pub, 99, 3, now); !errors.Is(err, anonauth.ErrRateLimited) {
+		t.Fatalf("expected ErrRateLimited, got %v", err)
+	}
+	if err := store.CheckAndIncrement(context.Background(), pub, 100, 3, now); err != nil {
+		t.Fatalf("expected reset in next epoch, got %v", err)
+	}
+}
+
+func TestStore_CheckAndIncrement_Expired(t *testing.T) {
+	t.Parallel()
+	store := newStore(t)
+	pub := freshKey(t)
+	now := time.Now()
+	_ = store.Register(context.Background(), pub, now.Add(-2*time.Hour), now.Add(-time.Hour))
+	err := store.CheckAndIncrement(context.Background(), pub, 1, 5, now)
+	if !errors.Is(err, anonauth.ErrPseudonymExpired) {
+		t.Fatalf("expected ErrPseudonymExpired, got %v", err)
+	}
+}
+
+func TestStore_CheckAndIncrement_NegativeEpochRejected(t *testing.T) {
+	t.Parallel()
+	store := newStore(t)
+	pub := freshKey(t)
+	now := time.Now()
+	_ = store.Register(context.Background(), pub, now, now.Add(time.Hour))
+	err := store.CheckAndIncrement(context.Background(), pub, -1, 5, now)
+	if err == nil {
+		t.Fatalf("negative epoch must be rejected")
+	}
+}
+
+func TestStore_DeleteExpired(t *testing.T) {
+	t.Parallel()
+	store := newStore(t)
+	now := time.Now()
+	live := freshKey(t)
+	dead := freshKey(t)
+	_ = store.Register(context.Background(), live, now, now.Add(time.Hour))
+	_ = store.Register(context.Background(), dead, now.Add(-2*time.Hour), now.Add(-time.Hour))
+	deleted, err := store.DeleteExpired(context.Background(), now)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", deleted)
+	}
+	// The live record must remain usable.
+	if err := store.CheckAndIncrement(context.Background(), live, 0, 1, now); err != nil {
+		t.Fatalf("live record gone after expired sweep: %v", err)
+	}
+}
+
+func TestStore_CheckAndIncrement_Concurrent(t *testing.T) {
+	t.Parallel()
+	store := newStore(t)
+	pub := freshKey(t)
+	now := time.Now()
+	_ = store.Register(context.Background(), pub, now, now.Add(time.Hour))
+
+	const limit = 50
+	const goroutines = 16
+	var ok atomic.Int64
+	var rejected atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < limit; j++ {
+				err := store.CheckAndIncrement(context.Background(), pub, 1, limit, now)
+				switch {
+				case err == nil:
+					ok.Add(1)
+				case errors.Is(err, anonauth.ErrRateLimited):
+					rejected.Add(1)
+				default:
+					t.Errorf("unexpected: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if ok.Load() != int64(limit) {
+		t.Fatalf("ok = %d, want exactly %d", ok.Load(), limit)
+	}
+	if rejected.Load() == 0 {
+		t.Fatalf("expected rejections under contention")
+	}
+}
+
+func TestStore_SurvivesRestart(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	var seed [32]byte
+	_, _ = rand.Read(seed[:])
+
+	first, err := sqlitestore.New(seed, dir)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	pub := freshKey(t)
+	now := time.Now()
+	_ = first.Register(context.Background(), pub, now, now.Add(time.Hour))
+	_ = first.Close()
+
+	second, err := sqlitestore.New(seed, dir)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = second.Close() }()
+	// Issuance against the persisted pseudonym must work after restart.
+	if err := second.CheckAndIncrement(context.Background(), pub, 0, 1, now); err != nil {
+		t.Fatalf("expected persisted pseudonym to remain usable: %v", err)
+	}
+}

--- a/server/internal/anonauth/testing.go
+++ b/server/internal/anonauth/testing.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package anonauth
+
+import (
+	"time"
+
+	"github.com/cloudflare/circl/oprf"
+)
+
+func newPartialObliviousServerForTest(key *IssuerKey) oprf.PartialObliviousServer {
+	return oprf.NewPartialObliviousServer(key.Suite(), key.privateKey())
+}
+
+// The helpers in this file are exported for the benefit of test
+// packages outside this one (notably internal/api/v1 integration
+// tests). They are NOT part of the production API: each name carries
+// a "ForTest" suffix so a slip into production code is loud at the
+// call site, and the godoc deliberately discourages non-test use.
+//
+// They live in a regular source file rather than `*_test.go` because
+// Go's external test packages cannot import test-only symbols from
+// another package; this is the standard workaround.
+
+// SetClockForTest replaces the issuer's clock with a deterministic
+// function. For tests only.
+func (i *Issuer) SetClockForTest(now func() time.Time) { i.now = now }
+
+// SetClockForTest replaces the verifier's clock with a deterministic
+// function. For tests only.
+func (v *Verifier) SetClockForTest(now func() time.Time) { v.now = now }
+
+// SetClockForTest replaces the PoW store clock. For tests only.
+func (s *PoWStore) SetClockForTest(now func() time.Time) { s.now = now }
+
+// SpentSetSizeForTest exposes the spent-set occupancy. For tests only.
+func (v *Verifier) SpentSetSizeForTest() int { return v.spent.size() }
+
+// CanonicalIssuancePayloadForTest exposes the canonical signing
+// payload so a test client can sign without duplicating the layout.
+// For tests only.
+func CanonicalIssuancePayloadForTest(epoch int64, blinded []byte) []byte {
+	return canonicalIssuancePayload(epoch, blinded)
+}
+
+// FullEvaluateForTest runs POPRF.FullEvaluate against the issuer key
+// for the supplied epoch info. Lets spent-set tests build verifier-
+// acceptable tokens without going through the blinded protocol.
+// For tests only.
+func FullEvaluateForTest(key *IssuerKey, input []byte, epoch int64) ([]byte, error) {
+	srv := newPartialObliviousServerForTest(key)
+	return srv.FullEvaluate(input, EpochInfo(epoch))
+}

--- a/server/internal/anonauth/verifier.go
+++ b/server/internal/anonauth/verifier.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package anonauth
+
+import (
+	"crypto/subtle"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/cloudflare/circl/oprf"
+)
+
+// VerifierConfig captures the verifier-side knobs. Epoch must match
+// the issuer; SpentSetCapacity bounds the in-memory replay map and
+// can be left zero to take the default.
+type VerifierConfig struct {
+	Epoch            time.Duration
+	SpentSetCapacity int
+}
+
+// Verifier consumes presented tokens. It is safe for concurrent use.
+//
+// The verifier accepts tokens for the current epoch and the
+// immediately preceding epoch; that one-epoch grace covers the case
+// where a client finalised a token a few seconds before the boundary
+// and presents it just after. Tokens older than that are rejected
+// because their POPRF FullEvaluate produces a different MAC, so the
+// constant-time compare fails.
+type Verifier struct {
+	cfg    VerifierConfig
+	server oprf.PartialObliviousServer
+	spent  *spentSet
+	now    func() time.Time
+}
+
+// NewVerifier constructs a verifier from the issuer's key. The
+// issuer and verifier share the same key material because POPRF
+// FullEvaluate requires the private scalar; this is identical to the
+// issuer-side oprf.PartialObliviousServer constructor and is fine to
+// instantiate twice.
+func NewVerifier(cfg VerifierConfig, key *IssuerKey) (*Verifier, error) {
+	if cfg.Epoch <= 0 {
+		return nil, fmt.Errorf("anonauth: VerifierConfig.Epoch must be > 0")
+	}
+	if key == nil {
+		return nil, fmt.Errorf("anonauth: IssuerKey is required")
+	}
+	return &Verifier{
+		cfg:    cfg,
+		server: oprf.NewPartialObliviousServer(key.Suite(), key.privateKey()),
+		spent:  newSpentSet(cfg.SpentSetCapacity),
+		now:    time.Now,
+	}, nil
+}
+
+// CurrentEpoch returns the epoch index for the supplied time using
+// the verifier's epoch duration. Times before the Unix epoch
+// collapse to 0; see computeEpoch for the shared logic.
+func (v *Verifier) CurrentEpoch(now time.Time) int64 {
+	return computeEpoch(now, v.cfg.Epoch)
+}
+
+// Verify checks that the supplied (input, mac) pair is a valid POPRF
+// finalised output for the current epoch or the immediately
+// preceding epoch, and records the mac in the spent set. Returns
+// ErrTokenInvalid for any cryptographic mismatch and
+// ErrTokenReplayed when the mac is already present and unexpired.
+//
+// MAC matching strategy: try the current epoch first, then the
+// previous epoch. Both calls go through subtle.ConstantTimeCompare so
+// the matched-epoch decision does not branch on a non-constant-time
+// path; the early-exit on the current epoch is intentional to bound
+// the worst-case CPU cost to two FullEvaluate calls plus two
+// constant-time compares.
+func (v *Verifier) Verify(input, mac []byte) error {
+	if len(input) == 0 || len(mac) == 0 {
+		return ErrTokenInvalid
+	}
+	now := v.now()
+	current := v.CurrentEpoch(now)
+
+	matchedEpoch, ok := v.matchEpoch(input, mac, current)
+	if !ok && current > 0 {
+		matchedEpoch, ok = v.matchEpoch(input, mac, current-1)
+	}
+	if !ok {
+		return ErrTokenInvalid
+	}
+
+	// Spent-set TTL: keep the entry until the matched epoch is no
+	// longer redeemable, i.e. one full epoch past matchedEpoch's
+	// boundary. After that the constant-time compare against either
+	// the current or previous epoch will already reject the token,
+	// so the entry can safely be evicted. The arithmetic is bound-
+	// checked because nothing else upstream prevents an absurdly
+	// large matchedEpoch from overflowing int64 once it is multiplied
+	// by an epoch in nanoseconds.
+	expiresAt := spentEntryExpiry(matchedEpoch, v.cfg.Epoch)
+	if !v.spent.markIfFresh(mac, expiresAt, now) {
+		return ErrTokenReplayed
+	}
+	return nil
+}
+
+func spentEntryExpiry(matchedEpoch int64, epoch time.Duration) time.Time {
+	epochNs := int64(epoch)
+	if epochNs <= 0 || matchedEpoch < 0 {
+		// Verifier construction guards epoch > 0 and matchedEpoch
+		// is computed by computeEpoch which returns 0 for negative
+		// times; reaching either branch means a misuse from a
+		// future caller.
+		return time.Unix(0, math.MaxInt64)
+	}
+	// Bound the product (matchedEpoch+2) * epochNs so it fits in
+	// int64; clamp to far-future on overflow rather than wrapping.
+	const grace = 2
+	if matchedEpoch > math.MaxInt64/epochNs-grace {
+		return time.Unix(0, math.MaxInt64)
+	}
+	return time.Unix(0, (matchedEpoch+grace)*epochNs)
+}
+
+// matchEpoch returns the epoch and true if FullEvaluate(input, epoch)
+// produces a byte-identical mac. The compare is constant-time.
+func (v *Verifier) matchEpoch(input, mac []byte, epoch int64) (int64, bool) {
+	expected, err := v.server.FullEvaluate(input, EpochInfo(epoch))
+	if err != nil {
+		return 0, false
+	}
+	if subtle.ConstantTimeCompare(expected, mac) != 1 {
+		return 0, false
+	}
+	return epoch, true
+}

--- a/server/internal/api/v1/anonauth.go
+++ b/server/internal/api/v1/anonauth.go
@@ -1,0 +1,222 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package v1
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/WissCore/moldchat/server/internal/anonauth"
+)
+
+// Body-size caps for the anonauth endpoints. The numbers are tight on
+// purpose: every field is a fixed-length byte string in base64, so a
+// generous cap would only buy a malformed-body reader extra work.
+const (
+	maxAnonauthRegisterBody = 4 * 1024
+	maxAnonauthIssueBody    = 4 * 1024
+)
+
+// mountAnonauth registers the anonymous-credential endpoints on mux.
+// The function is a no-op when neither s.Issuer nor s.Verifier is
+// set; the asymmetric-config check lives in Mount itself so a misuse
+// is rejected before any handler is registered.
+func (s *Server) mountAnonauth(mux *http.ServeMux) {
+	if s.Issuer == nil {
+		return
+	}
+	mux.Handle("GET /v1/pseudonyms/challenge", s.handlePseudonymChallenge())
+	mux.Handle("POST /v1/pseudonyms", s.handleRegisterPseudonym())
+	mux.Handle("POST /v1/tokens/issue", s.handleIssueToken())
+}
+
+// AnonauthEnabled reports whether the API server is configured to
+// enforce anonymous-credential gating on send operations. The send
+// handler consults this to decide whether to require the
+// X-Anonauth-Token header.
+func (s *Server) AnonauthEnabled() bool {
+	return s.Issuer != nil && s.Verifier != nil
+}
+
+func (s *Server) handlePseudonymChallenge() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		challenge, err := s.Issuer.PoWChallenge()
+		if errors.Is(err, anonauth.ErrIssuerSaturated) {
+			writeError(w, http.StatusServiceUnavailable, "issuer at capacity")
+			return
+		}
+		if err != nil {
+			s.logServerError("pow challenge", err)
+			writeError(w, http.StatusInternalServerError, "internal error")
+			return
+		}
+		issuerPub, err := s.Issuer.IssuerPublicKey()
+		if err != nil {
+			s.logServerError("issuer public key", err)
+			writeError(w, http.StatusInternalServerError, "internal error")
+			return
+		}
+		cfg := s.Issuer.Config()
+		writeJSON(w, http.StatusOK, map[string]any{
+			"challenge":             base64.StdEncoding.EncodeToString(challenge.Bytes),
+			"difficulty_bits":       challenge.DifficultyBits,
+			"expires_at":            challenge.ExpiresAt.Format(time.RFC3339),
+			"issuer_public_key":     base64.StdEncoding.EncodeToString(issuerPub),
+			"epoch_seconds":         int64(cfg.Epoch.Seconds()),
+			"tokens_per_epoch":      cfg.TokensPerEpoch,
+			"pseudonym_ttl_seconds": int64(cfg.PseudonymTTL.Seconds()),
+		})
+	})
+}
+
+func (s *Server) handleRegisterPseudonym() http.Handler {
+	type request struct {
+		PseudonymPub string `json:"pseudonym_public_key"`
+		Challenge    string `json:"challenge"`
+		Nonce        string `json:"nonce"`
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxAnonauthRegisterBody)
+		var req request
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid json body")
+			return
+		}
+		pub, err := base64.StdEncoding.DecodeString(req.PseudonymPub)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "pseudonym_public_key must be base64")
+			return
+		}
+		challenge, err := base64.StdEncoding.DecodeString(req.Challenge)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "challenge must be base64")
+			return
+		}
+		nonce, err := base64.StdEncoding.DecodeString(req.Nonce)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "nonce must be base64")
+			return
+		}
+		err = s.Issuer.RegisterPseudonym(r.Context(), ed25519.PublicKey(pub), challenge, nonce)
+		switch {
+		case errors.Is(err, anonauth.ErrPoWInvalid),
+			errors.Is(err, anonauth.ErrPoWChallengeUnknown),
+			errors.Is(err, anonauth.ErrPseudonymInvalid):
+			// All three collapse to the same wire response so the
+			// client cannot distinguish "wrong nonce" from "wrong
+			// challenge" from "wrong pubkey length".
+			writeError(w, http.StatusUnauthorized, "registration rejected")
+			return
+		case errors.Is(err, anonauth.ErrPseudonymExists):
+			writeError(w, http.StatusConflict, "pseudonym already registered")
+			return
+		case errors.Is(err, anonauth.ErrPseudonymCapacity):
+			writeError(w, http.StatusServiceUnavailable, "pseudonym store at capacity")
+			return
+		case err != nil:
+			s.logServerError("register pseudonym", err)
+			writeError(w, http.StatusInternalServerError, "internal error")
+			return
+		}
+		writeJSON(w, http.StatusCreated, map[string]any{
+			"registered_at": time.Now().UTC().Format(time.RFC3339),
+		})
+	})
+}
+
+func (s *Server) handleIssueToken() http.Handler {
+	type request struct {
+		PseudonymPub string `json:"pseudonym_public_key"`
+		Signature    string `json:"signature"`
+		Blinded      string `json:"blinded"`
+		Epoch        int64  `json:"epoch"`
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxAnonauthIssueBody)
+		var req request
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid json body")
+			return
+		}
+		pub, err := base64.StdEncoding.DecodeString(req.PseudonymPub)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "pseudonym_public_key must be base64")
+			return
+		}
+		sig, err := base64.StdEncoding.DecodeString(req.Signature)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "signature must be base64")
+			return
+		}
+		blinded, err := base64.StdEncoding.DecodeString(req.Blinded)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "blinded must be base64")
+			return
+		}
+		resp, err := s.Issuer.IssueToken(r.Context(), anonauth.IssuanceRequest{
+			Blinded:      blinded,
+			PseudonymPub: ed25519.PublicKey(pub),
+			Signature:    sig,
+			Epoch:        req.Epoch,
+		})
+		switch {
+		case errors.Is(err, anonauth.ErrPseudonymInvalid):
+			writeError(w, http.StatusUnauthorized, "issuance rejected")
+			return
+		case errors.Is(err, anonauth.ErrPseudonymExpired):
+			writeError(w, http.StatusUnauthorized, "pseudonym expired")
+			return
+		case errors.Is(err, anonauth.ErrRateLimited):
+			writeError(w, http.StatusTooManyRequests, "rate limit reached")
+			return
+		case err != nil:
+			s.logServerError("issue token", err)
+			writeError(w, http.StatusInternalServerError, "internal error")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"evaluation": base64.StdEncoding.EncodeToString(resp.Evaluation),
+			"proof_c":    base64.StdEncoding.EncodeToString(resp.ProofC),
+			"proof_s":    base64.StdEncoding.EncodeToString(resp.ProofS),
+			"epoch":      resp.Epoch,
+			"issued_at":  resp.IssuedAt.UTC().Format(time.RFC3339),
+		})
+	})
+}
+
+// AnonauthHeader is the request header that carries a presented
+// token on PUT /v1/queues/{id}/messages when anonauth is enforced.
+// Format: base64(input || mac), where input is the same byte string
+// the client supplied to POPRF.Blind and mac is the finalised output.
+const AnonauthHeader = "X-Anonauth-Token"
+
+// parseAnonauthToken decodes the token header into its (input, mac)
+// components. The mac length is fixed by the suite (SHA-512 → 64
+// bytes); anything shorter is an immediate reject. There is no upper
+// bound on input length here — input is whatever the client chose
+// at Blind time — but the wider HTTP layer caps the header size, so
+// the practical maximum is bounded already.
+func parseAnonauthToken(header string) (input, mac []byte, err error) {
+	if header == "" {
+		return nil, nil, anonauth.ErrTokenInvalid
+	}
+	raw, decErr := base64.StdEncoding.DecodeString(header)
+	if decErr != nil {
+		return nil, nil, anonauth.ErrTokenInvalid
+	}
+	const macLen = 64
+	if len(raw) <= macLen {
+		return nil, nil, anonauth.ErrTokenInvalid
+	}
+	return raw[:len(raw)-macLen], raw[len(raw)-macLen:], nil
+}

--- a/server/internal/api/v1/anonauth_fuzz_test.go
+++ b/server/internal/api/v1/anonauth_fuzz_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package v1
+
+import "testing"
+
+// FuzzParseAnonauthToken probes the token-header parser against
+// arbitrary inputs. The parser must never panic and must always
+// either return a valid (input, mac) split with the expected mac
+// length or an error; anything else turns the parser into a denial-
+// of-service surface.
+func FuzzParseAnonauthToken(f *testing.F) {
+	f.Add("")
+	f.Add("AAAA")
+	f.Add("not!base64!")
+	f.Add("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+	f.Fuzz(func(t *testing.T, header string) {
+		input, mac, err := parseAnonauthToken(header)
+		if err != nil {
+			if input != nil || mac != nil {
+				t.Fatalf("error path returned non-nil slices")
+			}
+			return
+		}
+		const macLen = 64
+		if len(mac) != macLen {
+			t.Fatalf("mac length %d, want %d", len(mac), macLen)
+		}
+		if len(input) == 0 {
+			t.Fatalf("non-error parse returned empty input")
+		}
+	})
+}

--- a/server/internal/api/v1/anonauth_test.go
+++ b/server/internal/api/v1/anonauth_test.go
@@ -1,0 +1,431 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package v1_test
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/WissCore/moldchat/server/internal/anonauth"
+	v1 "github.com/WissCore/moldchat/server/internal/api/v1"
+	"github.com/WissCore/moldchat/server/internal/auth"
+	"github.com/WissCore/moldchat/server/internal/storage/memory"
+	"github.com/cloudflare/circl/group"
+	"github.com/cloudflare/circl/oprf"
+	dleqpkg "github.com/cloudflare/circl/zk/dleq"
+)
+
+// anonauthTestServer wires the API with anonauth enforcement enabled
+// and exposes the issuer/verifier so tests can drive their clocks.
+type anonauthTestServer struct {
+	*httptest.Server
+	api      *v1.Server
+	issuer   *anonauth.Issuer
+	verifier *anonauth.Verifier
+	key      *anonauth.IssuerKey
+}
+
+func newAnonauthServer(t *testing.T, cfg anonauth.IssuerConfig, now time.Time) *anonauthTestServer {
+	t.Helper()
+	seed := make([]byte, 32)
+	if _, err := rand.Read(seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	key, err := anonauth.DeriveIssuerKey(seed)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	issuer, err := anonauth.NewIssuer(cfg, key, anonauth.NewMemoryPseudonymStore())
+	if err != nil {
+		t.Fatalf("issuer: %v", err)
+	}
+	verifier, err := anonauth.NewVerifier(anonauth.VerifierConfig{Epoch: cfg.Epoch}, key)
+	if err != nil {
+		t.Fatalf("verifier: %v", err)
+	}
+	issuer.SetClockForTest(func() time.Time { return now })
+	verifier.SetClockForTest(func() time.Time { return now })
+
+	mux := http.NewServeMux()
+	api := &v1.Server{
+		Storage:  memory.New(),
+		Auth:     auth.NewIssuer(),
+		Issuer:   issuer,
+		Verifier: verifier,
+	}
+	api.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return &anonauthTestServer{Server: srv, api: api, issuer: issuer, verifier: verifier, key: key}
+}
+
+// solvePoWHTTP grinds nonces locally — same algorithm as in the
+// package-internal pow tests, kept here to avoid a cross-test
+// dependency on internal helpers.
+func solvePoWHTTP(tb testing.TB, challenge []byte, bits uint8) []byte {
+	tb.Helper()
+	nonce := make([]byte, 8)
+	for i := uint64(0); ; i++ {
+		binary.BigEndian.PutUint64(nonce, i)
+		h := sha256.Sum256(append(append([]byte{}, challenge...), nonce...))
+		if leadingZeros(h[:]) >= int(bits) {
+			out := append([]byte{}, nonce...)
+			return out
+		}
+		if i > 1<<28 {
+			tb.Fatalf("pow grinding budget exceeded")
+		}
+	}
+}
+
+func leadingZeros(b []byte) int {
+	n := 0
+	for _, x := range b {
+		if x == 0 {
+			n += 8
+			continue
+		}
+		for mask := byte(0x80); mask != 0; mask >>= 1 {
+			if x&mask == 0 {
+				n++
+			} else {
+				return n
+			}
+		}
+		return n
+	}
+	return n
+}
+
+// fetchPseudonymChallenge calls GET /v1/pseudonyms/challenge and
+// decodes the response.
+func fetchPseudonymChallenge(t *testing.T, baseURL string) (challenge []byte, bits uint8, issuerPub []byte) {
+	t.Helper()
+	resp, err := http.Get(baseURL + "/v1/pseudonyms/challenge")
+	if err != nil {
+		t.Fatalf("get challenge: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("challenge status: %d", resp.StatusCode)
+	}
+	var got struct {
+		Challenge       string `json:"challenge"`
+		DifficultyBits  uint8  `json:"difficulty_bits"`
+		IssuerPublicKey string `json:"issuer_public_key"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	cb, _ := base64.StdEncoding.DecodeString(got.Challenge)
+	pk, _ := base64.StdEncoding.DecodeString(got.IssuerPublicKey)
+	return cb, got.DifficultyBits, pk
+}
+
+// registerPseudonymHTTP runs the full registration flow against the
+// HTTP API and returns the freshly minted Ed25519 key pair.
+func registerPseudonymHTTP(t *testing.T, baseURL string) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519: %v", err)
+	}
+	challenge, bits, _ := fetchPseudonymChallenge(t, baseURL)
+	nonce := solvePoWHTTP(t, challenge, bits)
+	body, _ := json.Marshal(map[string]string{
+		"pseudonym_public_key": base64.StdEncoding.EncodeToString(pub),
+		"challenge":            base64.StdEncoding.EncodeToString(challenge),
+		"nonce":                base64.StdEncoding.EncodeToString(nonce),
+	})
+	resp, err := http.Post(baseURL+"/v1/pseudonyms", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post pseudonym: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		buf, _ := io.ReadAll(resp.Body)
+		t.Fatalf("register status: %d body: %s", resp.StatusCode, buf)
+	}
+	return pub, priv
+}
+
+// issueTokenHTTP does the full token issuance against the HTTP API
+// and returns the (input, mac) the client would present.
+func issueTokenHTTP(t *testing.T, baseURL string, srv *anonauthTestServer, pub ed25519.PublicKey, priv ed25519.PrivateKey, now time.Time) (input, mac []byte) {
+	t.Helper()
+	suite := srv.key.Suite()
+	pubKey, _ := srv.key.PublicKey()
+	parsedPub := new(oprf.PublicKey)
+	if err := parsedPub.UnmarshalBinary(suite, pubKey); err != nil {
+		t.Fatalf("parse issuer pub: %v", err)
+	}
+	client := oprf.NewPartialObliviousClient(suite, parsedPub)
+	input = make([]byte, 16)
+	if _, err := rand.Read(input); err != nil {
+		t.Fatalf("input: %v", err)
+	}
+	finData, evalReq, err := client.Blind([][]byte{input})
+	if err != nil {
+		t.Fatalf("blind: %v", err)
+	}
+	blinded, _ := evalReq.Elements[0].MarshalBinaryCompress()
+
+	epoch := srv.issuer.CurrentEpoch(now)
+	signed := anonauth.CanonicalIssuancePayloadForTest(epoch, blinded)
+	sig := ed25519.Sign(priv, signed)
+	body, _ := json.Marshal(map[string]any{
+		"pseudonym_public_key": base64.StdEncoding.EncodeToString(pub),
+		"signature":            base64.StdEncoding.EncodeToString(sig),
+		"blinded":              base64.StdEncoding.EncodeToString(blinded),
+		"epoch":                epoch,
+	})
+	resp, err := http.Post(baseURL+"/v1/tokens/issue", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		buf, _ := io.ReadAll(resp.Body)
+		t.Fatalf("issue status: %d body: %s", resp.StatusCode, buf)
+	}
+	var got struct {
+		Evaluation string `json:"evaluation"`
+		ProofC     string `json:"proof_c"`
+		ProofS     string `json:"proof_s"`
+	}
+	if decErr := json.NewDecoder(resp.Body).Decode(&got); decErr != nil {
+		t.Fatalf("decode: %v", decErr)
+	}
+	evalBytes, _ := base64.StdEncoding.DecodeString(got.Evaluation)
+	cBytes, _ := base64.StdEncoding.DecodeString(got.ProofC)
+	sBytes, _ := base64.StdEncoding.DecodeString(got.ProofS)
+	evalElement := suite.Group().NewElement()
+	if elemErr := evalElement.UnmarshalBinary(evalBytes); elemErr != nil {
+		t.Fatalf("unmarshal eval: %v", elemErr)
+	}
+	proof := &dleqpkg.Proof{}
+	if proofErr := proof.UnmarshalBinary(suite.Group(), append(cBytes, sBytes...)); proofErr != nil {
+		t.Fatalf("unmarshal proof: %v", proofErr)
+	}
+	evaluation := &oprf.Evaluation{Elements: []group.Element{evalElement}, Proof: proof}
+	outputs, err := client.Finalize(finData, evaluation, anonauth.EpochInfo(epoch))
+	if err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	return input, outputs[0]
+}
+
+// putWithToken posts a body to PUT /messages with the supplied
+// token in the X-Anonauth-Token header.
+func putWithToken(t *testing.T, baseURL, queueID string, body []byte, token string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPut, baseURL+"/v1/queues/"+queueID+"/messages", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new put: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	if token != "" {
+		req.Header.Set(v1.AnonauthHeader, token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	return resp
+}
+
+func encodeToken(input, mac []byte) string {
+	return base64.StdEncoding.EncodeToString(append(append([]byte{}, input...), mac...))
+}
+
+func TestAnonauth_EndToEnd(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	srv := newAnonauthServer(t, anonauth.IssuerConfig{
+		Epoch:             time.Hour,
+		PseudonymTTL:      24 * time.Hour,
+		TokensPerEpoch:    2,
+		PoWDifficultyBits: 4,
+	}, now)
+
+	owner := newOwner(t)
+	queueID := createQueue(t, srv.URL, owner)
+
+	pub, priv := registerPseudonymHTTP(t, srv.URL)
+
+	// Spend the per-epoch quota.
+	for i := 0; i < 2; i++ {
+		input, mac := issueTokenHTTP(t, srv.URL, srv, pub, priv, now)
+		resp := putWithToken(t, srv.URL, queueID, []byte("hello"), encodeToken(input, mac))
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusAccepted {
+			t.Fatalf("PUT %d: status %d, want 202", i, resp.StatusCode)
+		}
+	}
+
+	// Third issuance must hit the rate limit.
+	{
+		challenge, _ := bytes.NewReader(nil), 0
+		_ = challenge
+		// Construct manually because issueTokenHTTP would Fatalf
+		// on the expected 429.
+		suite := srv.key.Suite()
+		pubKey, _ := srv.key.PublicKey()
+		parsedPub := new(oprf.PublicKey)
+		_ = parsedPub.UnmarshalBinary(suite, pubKey)
+		client := oprf.NewPartialObliviousClient(suite, parsedPub)
+		_, evalReq, _ := client.Blind([][]byte{[]byte("third")})
+		blinded, _ := evalReq.Elements[0].MarshalBinaryCompress()
+		epoch := srv.issuer.CurrentEpoch(now)
+		signed := anonauth.CanonicalIssuancePayloadForTest(epoch, blinded)
+		sig := ed25519.Sign(priv, signed)
+		body, _ := json.Marshal(map[string]any{
+			"pseudonym_public_key": base64.StdEncoding.EncodeToString(pub),
+			"signature":            base64.StdEncoding.EncodeToString(sig),
+			"blinded":              base64.StdEncoding.EncodeToString(blinded),
+			"epoch":                epoch,
+		})
+		resp, err := http.Post(srv.URL+"/v1/tokens/issue", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusTooManyRequests {
+			t.Fatalf("expected 429, got %d", resp.StatusCode)
+		}
+	}
+}
+
+func TestAnonauth_PutWithoutTokenRejected(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	srv := newAnonauthServer(t, anonauth.IssuerConfig{
+		Epoch:             time.Hour,
+		PseudonymTTL:      24 * time.Hour,
+		TokensPerEpoch:    5,
+		PoWDifficultyBits: 4,
+	}, now)
+	owner := newOwner(t)
+	queueID := createQueue(t, srv.URL, owner)
+
+	resp := putWithToken(t, srv.URL, queueID, []byte("hello"), "")
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without token, got %d", resp.StatusCode)
+	}
+}
+
+func TestAnonauth_PutWithReplayedTokenRejected(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	srv := newAnonauthServer(t, anonauth.IssuerConfig{
+		Epoch:             time.Hour,
+		PseudonymTTL:      24 * time.Hour,
+		TokensPerEpoch:    5,
+		PoWDifficultyBits: 4,
+	}, now)
+	owner := newOwner(t)
+	queueID := createQueue(t, srv.URL, owner)
+
+	pub, priv := registerPseudonymHTTP(t, srv.URL)
+	input, mac := issueTokenHTTP(t, srv.URL, srv, pub, priv, now)
+	token := encodeToken(input, mac)
+
+	first := putWithToken(t, srv.URL, queueID, []byte("hello"), token)
+	_ = first.Body.Close()
+	if first.StatusCode != http.StatusAccepted {
+		t.Fatalf("first PUT: %d", first.StatusCode)
+	}
+	second := putWithToken(t, srv.URL, queueID, []byte("hello"), token)
+	_ = second.Body.Close()
+	if second.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 on replay, got %d", second.StatusCode)
+	}
+}
+
+func TestAnonauth_PutWithGarbledTokenRejected(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	srv := newAnonauthServer(t, anonauth.IssuerConfig{
+		Epoch:             time.Hour,
+		PseudonymTTL:      24 * time.Hour,
+		TokensPerEpoch:    5,
+		PoWDifficultyBits: 4,
+	}, now)
+	owner := newOwner(t)
+	queueID := createQueue(t, srv.URL, owner)
+
+	cases := []string{
+		"!!!not-base64!!!",
+		base64.StdEncoding.EncodeToString(make([]byte, 10)), // too short for input+mac
+	}
+	for _, c := range cases {
+		resp := putWithToken(t, srv.URL, queueID, []byte("x"), c)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("token %q: status %d, want 401", c, resp.StatusCode)
+		}
+	}
+}
+
+func TestAnonauth_BackwardCompatWhenDisabled(t *testing.T) {
+	t.Parallel()
+	// Construct a server WITHOUT Issuer/Verifier — anonauth disabled.
+	mux := http.NewServeMux()
+	api := &v1.Server{Storage: memory.New(), Auth: auth.NewIssuer()}
+	api.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	owner := newOwner(t)
+	queueID := createQueue(t, srv.URL, owner)
+	resp := putWithToken(t, srv.URL, queueID, []byte("hi"), "")
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("backward-compat PUT without token: status %d, want 202", resp.StatusCode)
+	}
+}
+
+func TestAnonauth_HalfConfiguredMountPanics(t *testing.T) {
+	t.Parallel()
+	// Issuer set, Verifier nil — must panic at Mount time so the
+	// half-configured state cannot reach a request handler.
+	now := time.Now()
+	seed := make([]byte, 32)
+	if _, err := rand.Read(seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	key, err := anonauth.DeriveIssuerKey(seed)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	issuer, err := anonauth.NewIssuer(anonauth.IssuerConfig{
+		Epoch:             time.Hour,
+		PseudonymTTL:      time.Hour,
+		TokensPerEpoch:    1,
+		PoWDifficultyBits: 4,
+	}, key, anonauth.NewMemoryPseudonymStore())
+	if err != nil {
+		t.Fatalf("issuer: %v", err)
+	}
+	issuer.SetClockForTest(func() time.Time { return now })
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for half-configured anonauth wiring")
+		}
+	}()
+	api := &v1.Server{Storage: memory.New(), Auth: auth.NewIssuer(), Issuer: issuer}
+	api.Mount(http.NewServeMux())
+}

--- a/server/internal/api/v1/api.go
+++ b/server/internal/api/v1/api.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"sync/atomic"
 
+	"github.com/WissCore/moldchat/server/internal/anonauth"
 	"github.com/WissCore/moldchat/server/internal/auth"
 	"github.com/WissCore/moldchat/server/internal/storage"
 )
@@ -42,10 +43,25 @@ type Server struct {
 	Auth             *auth.Issuer
 	Logger           *slog.Logger
 	AuthFailureCount atomic.Uint64
+
+	// Issuer and Verifier are the anonymous-credential server
+	// pieces. When both are non-nil the API enforces the
+	// X-Anonauth-Token header on PUT /v1/queues/{id}/messages and
+	// the issuance endpoints from MountAnonauth become live. Leaving
+	// either nil disables the feature entirely; the existing send
+	// path then accepts unauthenticated PUTs as before.
+	Issuer   *anonauth.Issuer
+	Verifier *anonauth.Verifier
 }
 
 // Mount registers the v1 routes on the supplied mux. Storage and Auth
 // must already be set; Mount panics otherwise to fail loudly at startup.
+//
+// Anonauth wiring is all-or-nothing: setting one of Issuer or
+// Verifier without the other is a misconfiguration that would mount
+// the issuance endpoints without the matching enforcement on PUT
+// (or vice versa), so Mount panics in that case to surface the bug
+// at startup rather than at request time.
 func (s *Server) Mount(mux *http.ServeMux) {
 	if s.Storage == nil {
 		panic("v1.Server.Storage must be set before Mount")
@@ -53,9 +69,13 @@ func (s *Server) Mount(mux *http.ServeMux) {
 	if s.Auth == nil {
 		panic("v1.Server.Auth must be set before Mount")
 	}
+	if (s.Issuer == nil) != (s.Verifier == nil) {
+		panic("v1.Server.Issuer and v1.Server.Verifier must be set together or both left nil")
+	}
 	mux.Handle("POST /v1/queues", s.handleCreateQueue())
 	mux.Handle("GET /v1/queues/{id}/auth-challenge", s.handleAuthChallenge())
 	mux.Handle("PUT /v1/queues/{id}/messages", s.handlePutMessage())
 	mux.Handle("GET /v1/queues/{id}/messages", s.handleListMessages())
 	mux.Handle("DELETE /v1/queues/{id}/messages/{mid}", s.handleDeleteMessage())
+	s.mountAnonauth(mux)
 }

--- a/server/internal/api/v1/log_audit_test.go
+++ b/server/internal/api/v1/log_audit_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package v1_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/WissCore/moldchat/server/internal/anonauth"
+	v1 "github.com/WissCore/moldchat/server/internal/api/v1"
+	"github.com/WissCore/moldchat/server/internal/auth"
+	"github.com/WissCore/moldchat/server/internal/storage/memory"
+)
+
+// TestLogAudit_AnonauthFlowDoesNotLeakSecrets runs the full anonauth
+// happy-path against an httptest server whose logger writes to an
+// in-memory buffer. After the flow completes, the buffer is scanned
+// for substrings that would indicate a leak: per-request blinded
+// elements, finalised MACs, pseudonym pubkeys, queue identifiers.
+//
+// This is the only test that asserts the package-level claim that
+// "no per-request crypto material reaches the logs"; if a future
+// edit ever adds slog calls that include those fields, this test
+// fails immediately.
+func TestLogAudit_AnonauthFlowDoesNotLeakSecrets(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	// slog.JSONHandler serialises writes to its underlying io.Writer
+	// with an internal mutex (documented in slog.NewJSONHandler), so
+	// a plain bytes.Buffer is safe to share across the handler's
+	// concurrent callers.
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	seed := make([]byte, 32)
+	if _, err := rand.Read(seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	key, err := anonauth.DeriveIssuerKey(seed)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	issuer, err := anonauth.NewIssuer(anonauth.IssuerConfig{
+		Epoch:             time.Hour,
+		PseudonymTTL:      24 * time.Hour,
+		TokensPerEpoch:    5,
+		PoWDifficultyBits: 4,
+	}, key, anonauth.NewMemoryPseudonymStore())
+	if err != nil {
+		t.Fatalf("issuer: %v", err)
+	}
+	verifier, err := anonauth.NewVerifier(anonauth.VerifierConfig{Epoch: time.Hour}, key)
+	if err != nil {
+		t.Fatalf("verifier: %v", err)
+	}
+	issuer.SetClockForTest(func() time.Time { return now })
+	verifier.SetClockForTest(func() time.Time { return now })
+
+	mux := http.NewServeMux()
+	api := &v1.Server{
+		Storage:  memory.New(),
+		Auth:     auth.NewIssuer(),
+		Logger:   logger,
+		Issuer:   issuer,
+		Verifier: verifier,
+	}
+	api.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	owner := newOwner(t)
+	queueID := createQueue(t, srv.URL, owner)
+	pub, priv := registerPseudonymHTTP(t, srv.URL)
+	stack := &anonauthTestServer{Server: srv, api: api, issuer: issuer, verifier: verifier, key: key}
+	input, mac := issueTokenHTTP(t, srv.URL, stack, pub, priv, now)
+
+	resp := putWithToken(t, srv.URL, queueID, []byte("payload"), encodeToken(input, mac))
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("PUT status %d", resp.StatusCode)
+	}
+
+	logged := logBuf.String()
+
+	// Forbidden substrings: anything that would let an attacker who
+	// reads the logs link a presented token to its issuance, or
+	// discover which queues exist. Per-substring assertions, so a
+	// regression points at the offending field.
+	forbidden := map[string]string{
+		"queue id in logs":         queueID,
+		"pseudonym pubkey in logs": base64.StdEncoding.EncodeToString(pub),
+		"token mac in logs":        base64.StdEncoding.EncodeToString(mac),
+		"token input in logs":      base64.StdEncoding.EncodeToString(input),
+		"raw header field in logs": v1.AnonauthHeader,
+	}
+	for label, needle := range forbidden {
+		if needle == "" {
+			continue
+		}
+		if strings.Contains(logged, needle) {
+			t.Errorf("%s: substring %q found in log output", label, needle)
+		}
+	}
+}

--- a/server/internal/api/v1/queues.go
+++ b/server/internal/api/v1/queues.go
@@ -125,6 +125,27 @@ func (s *Server) handlePutMessage() http.Handler {
 			writeError(w, http.StatusNotFound, "queue not found")
 			return
 		}
+		// Anonauth gate: enforced only when the server is configured
+		// with both an Issuer and a Verifier. The token is checked
+		// BEFORE the body is read for the same reason as the queue
+		// id check above — an unauthenticated client must not be
+		// able to make us absorb a 64 KiB body just to fail at the
+		// last step. The verifier collapses every failure mode
+		// (missing header, bad base64, wrong mac, replayed mac) to
+		// a single 401 so the response is not a side channel.
+		if s.AnonauthEnabled() {
+			input, mac, parseErr := parseAnonauthToken(r.Header.Get(AnonauthHeader))
+			if parseErr != nil {
+				s.AuthFailureCount.Add(1)
+				writeError(w, http.StatusUnauthorized, "anonymous token required")
+				return
+			}
+			if verifyErr := s.Verifier.Verify(input, mac); verifyErr != nil {
+				s.AuthFailureCount.Add(1)
+				writeError(w, http.StatusUnauthorized, "anonymous token rejected")
+				return
+			}
+		}
 		r.Body = http.MaxBytesReader(w, r.Body, queue.MaxBlobSize+1)
 		blob, err := io.ReadAll(r.Body)
 		if err != nil {

--- a/server/internal/smoke/anonauth_smoke.go
+++ b/server/internal/smoke/anonauth_smoke.go
@@ -1,0 +1,253 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//go:build smoke
+
+package smoke
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/WissCore/moldchat/server/internal/anonauth"
+	"github.com/cloudflare/circl/group"
+	"github.com/cloudflare/circl/oprf"
+	dleqpkg "github.com/cloudflare/circl/zk/dleq"
+)
+
+func init() {
+	RegisterCase(Case{
+		Name: "AnonauthEndToEndSendsMessage",
+		Run:  anonauthEndToEndCase,
+	})
+	RegisterCase(Case{
+		Name: "AnonauthRejectsSendWithoutToken",
+		Run:  anonauthRejectsWithoutTokenCase,
+	})
+}
+
+func anonauthEndToEndCase(t *testing.T, fix *Fixtures) {
+	srv := fix.StartServer(t, ServerOptions{EnableAnonauth: true})
+	owner := mintOwner(t)
+	queueID := smokeCreateQueue(t, srv.BaseURL, owner)
+
+	reg := registerPseudonymAndFetchIssuerPub(t, srv.BaseURL)
+	input, mac := issueAndFinalizeToken(t, srv.BaseURL, reg)
+
+	token := base64.StdEncoding.EncodeToString(append(append([]byte{}, input...), mac...))
+	mid := smokePutMessage(t, srv.BaseURL, queueID, []byte("with-anon-token"), token)
+	if mid == "" {
+		t.Fatal("anonauth-gated put returned empty message_id")
+	}
+}
+
+func anonauthRejectsWithoutTokenCase(t *testing.T, fix *Fixtures) {
+	srv := fix.StartServer(t, ServerOptions{EnableAnonauth: true})
+	owner := mintOwner(t)
+	queueID := smokeCreateQueue(t, srv.BaseURL, owner)
+
+	req, err := http.NewRequest(http.MethodPut, srv.BaseURL+"/v1/queues/"+queueID+"/messages", bytes.NewReader([]byte("naked")))
+	if err != nil {
+		t.Fatalf("build put: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		buf, _ := io.ReadAll(resp.Body)
+		t.Fatalf("naked put status %d, want 401: %s", resp.StatusCode, buf)
+	}
+}
+
+// pseudonymRegistration bundles everything a follow-up
+// issueAndFinalizeToken call needs: the pseudonym key pair, the
+// POPRF suite + issuer public key parsed from the same challenge
+// response, and the server's epoch_seconds so the client can compute
+// the current epoch index without a second challenge round trip.
+type pseudonymRegistration struct {
+	pub          ed25519.PublicKey
+	priv         ed25519.PrivateKey
+	suite        oprf.Suite
+	issuerPub    *oprf.PublicKey
+	epochSeconds int64
+}
+
+// registerPseudonymAndFetchIssuerPub does the GET /pseudonyms/challenge
+// → solve PoW → POST /pseudonyms exchange and returns the freshly
+// minted Ed25519 keypair plus everything the issuance step needs
+// later. Reading epoch_seconds out of the same challenge response we
+// already parse avoids a second /pseudonyms/challenge round trip
+// (and the wasted outstanding-challenge slot it would consume).
+func registerPseudonymAndFetchIssuerPub(t *testing.T, baseURL string) pseudonymRegistration {
+	t.Helper()
+	resp, err := http.Get(baseURL + "/v1/pseudonyms/challenge")
+	if err != nil {
+		t.Fatalf("challenge: %v", err)
+	}
+	var ch struct {
+		Challenge       string `json:"challenge"`
+		DifficultyBits  uint8  `json:"difficulty_bits"`
+		IssuerPublicKey string `json:"issuer_public_key"`
+		EpochSeconds    int64  `json:"epoch_seconds"`
+	}
+	if decErr := json.NewDecoder(resp.Body).Decode(&ch); decErr != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("decode challenge: %v", decErr)
+	}
+	_ = resp.Body.Close()
+	if ch.EpochSeconds <= 0 {
+		t.Fatalf("challenge epoch_seconds = %d, want > 0", ch.EpochSeconds)
+	}
+	challenge, _ := base64.StdEncoding.DecodeString(ch.Challenge)
+	issuerPubBytes, _ := base64.StdEncoding.DecodeString(ch.IssuerPublicKey)
+
+	nonce := solveSmokePoW(t, challenge, ch.DifficultyBits)
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519: %v", err)
+	}
+	body, _ := json.Marshal(map[string]string{
+		"pseudonym_public_key": base64.StdEncoding.EncodeToString(pub),
+		"challenge":            base64.StdEncoding.EncodeToString(challenge),
+		"nonce":                base64.StdEncoding.EncodeToString(nonce),
+	})
+	resp, err = http.Post(baseURL+"/v1/pseudonyms", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		buf, _ := io.ReadAll(resp.Body)
+		t.Fatalf("register status %d: %s", resp.StatusCode, buf)
+	}
+
+	suite := anonauth.Suite()
+	issuerPub := new(oprf.PublicKey)
+	if pkErr := issuerPub.UnmarshalBinary(suite, issuerPubBytes); pkErr != nil {
+		t.Fatalf("unmarshal issuer pub: %v", pkErr)
+	}
+	return pseudonymRegistration{
+		pub:          pub,
+		priv:         priv,
+		suite:        suite,
+		issuerPub:    issuerPub,
+		epochSeconds: ch.EpochSeconds,
+	}
+}
+
+// issueAndFinalizeToken runs Blind → POST /tokens/issue → Finalize and
+// returns a token (input, mac) ready to present in X-Anonauth-Token.
+func issueAndFinalizeToken(t *testing.T, baseURL string, reg pseudonymRegistration) ([]byte, []byte) {
+	t.Helper()
+	client := oprf.NewPartialObliviousClient(reg.suite, reg.issuerPub)
+	input := make([]byte, 16)
+	if _, err := rand.Read(input); err != nil {
+		t.Fatalf("rand input: %v", err)
+	}
+	finData, evalReq, err := client.Blind([][]byte{input})
+	if err != nil {
+		t.Fatalf("blind: %v", err)
+	}
+	blinded, _ := evalReq.Elements[0].MarshalBinaryCompress()
+
+	// Compute the current epoch from the server-supplied
+	// epoch_seconds and the local clock. Smoke runs against a
+	// process on the same host so clock skew is not a concern.
+	epoch := time.Now().Unix() / reg.epochSeconds
+	signed := anonauth.CanonicalIssuancePayloadForTest(epoch, blinded)
+	sig := ed25519.Sign(reg.priv, signed)
+
+	body, _ := json.Marshal(map[string]any{
+		"pseudonym_public_key": base64.StdEncoding.EncodeToString(reg.pub),
+		"signature":            base64.StdEncoding.EncodeToString(sig),
+		"blinded":              base64.StdEncoding.EncodeToString(blinded),
+		"epoch":                epoch,
+	})
+	resp, err := http.Post(baseURL+"/v1/tokens/issue", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		buf, _ := io.ReadAll(resp.Body)
+		t.Fatalf("issue status %d: %s", resp.StatusCode, buf)
+	}
+	var got struct {
+		Evaluation string `json:"evaluation"`
+		ProofC     string `json:"proof_c"`
+		ProofS     string `json:"proof_s"`
+	}
+	if decErr := json.NewDecoder(resp.Body).Decode(&got); decErr != nil {
+		t.Fatalf("decode issue: %v", decErr)
+	}
+	evalBytes, _ := base64.StdEncoding.DecodeString(got.Evaluation)
+	cBytes, _ := base64.StdEncoding.DecodeString(got.ProofC)
+	sBytes, _ := base64.StdEncoding.DecodeString(got.ProofS)
+	evalElement := reg.suite.Group().NewElement()
+	if elemErr := evalElement.UnmarshalBinary(evalBytes); elemErr != nil {
+		t.Fatalf("unmarshal eval: %v", elemErr)
+	}
+	proof := &dleqpkg.Proof{}
+	if proofErr := proof.UnmarshalBinary(reg.suite.Group(), append(cBytes, sBytes...)); proofErr != nil {
+		t.Fatalf("unmarshal proof: %v", proofErr)
+	}
+	evaluation := &oprf.Evaluation{Elements: []group.Element{evalElement}, Proof: proof}
+	outputs, err := client.Finalize(finData, evaluation, anonauth.EpochInfo(epoch))
+	if err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	return input, outputs[0]
+}
+
+// solveSmokePoW grinds an 8-byte nonce until SHA-256 of (challenge ||
+// nonce) has at least bits leading zero bits. Mirrors the helper in
+// the anonauth tests; duplicated here to keep the smoke package
+// self-contained.
+func solveSmokePoW(t *testing.T, challenge []byte, bits uint8) []byte {
+	t.Helper()
+	nonce := make([]byte, 8)
+	for i := uint64(0); ; i++ {
+		binary.BigEndian.PutUint64(nonce, i)
+		h := sha256.Sum256(append(append([]byte{}, challenge...), nonce...))
+		if leadingZeroBits(h[:]) >= int(bits) {
+			out := append([]byte{}, nonce...)
+			return out
+		}
+		if i > 1<<28 {
+			t.Fatalf("smoke pow grinding budget exceeded")
+		}
+	}
+}
+
+func leadingZeroBits(b []byte) int {
+	n := 0
+	for _, x := range b {
+		if x == 0 {
+			n += 8
+			continue
+		}
+		for mask := byte(0x80); mask != 0; mask >>= 1 {
+			if x&mask == 0 {
+				n++
+			} else {
+				return n
+			}
+		}
+		return n
+	}
+	return n
+}

--- a/server/internal/smoke/binary_smoke.go
+++ b/server/internal/smoke/binary_smoke.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//go:build smoke
+
+package smoke
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// newCmdContext builds an *exec.Cmd for the moldd binary with the
+// supplied env and a context-bound lifetime, intended for cases that
+// intentionally exercise the failure path (where the binary is
+// expected to exit non-zero before /healthz would respond, so
+// StartServer's healthz-wait would hang). The ctx makes it
+// observable when the binary refuses to exit at all — without it,
+// the test would silently consume the outer go-test timeout.
+// Stdout and stderr are discarded; tests that need them can override.
+func newCmdContext(ctx context.Context, t *testing.T, fix *Fixtures, env []string) *exec.Cmd {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, fix.BinaryPath)
+	cmd.Env = env
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	return cmd
+}
+
+func init() {
+	RegisterCase(Case{
+		Name: "BinaryStartsServesHealthzAndStopsCleanly",
+		Run:  binaryHealthzCase,
+	})
+	RegisterCase(Case{
+		Name: "BinaryRejectsUnknownAnonauthMode",
+		Run:  binaryRejectsBadAnonauthCase,
+	})
+}
+
+func binaryHealthzCase(t *testing.T, fix *Fixtures) {
+	srv := fix.StartServer(t, ServerOptions{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.BaseURL+"/healthz", nil)
+	if err != nil {
+		t.Fatalf("build healthz: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("healthz: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("healthz status %d, want 200", resp.StatusCode)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("healthz body: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Fatalf("healthz body[status] = %q, want ok", body["status"])
+	}
+
+	srv.Stop() // drives graceful shutdown and asserts exit 0
+}
+
+// binaryRejectsBadAnonauthCase confirms main.go validates env values
+// and exits non-zero on a bogus MOLDD_ANONAUTH setting. We exercise
+// the failure path by spawning the binary directly (not via
+// StartServer, which would wait for /healthz that never arrives) and
+// checking the exit code under a bounded context. The bound matters
+// because a regression that makes the binary hang on bad config
+// would otherwise burn the whole `-timeout` window of `go test`
+// before reporting failure.
+func binaryRejectsBadAnonauthCase(t *testing.T, fix *Fixtures) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := newCmdContext(ctx, t, fix, []string{
+		"MOLDD_STORAGE=memory",
+		"MOLDD_ANONAUTH=invalid-mode",
+	})
+	err := cmd.Run()
+	switch {
+	case err == nil:
+		t.Fatalf("expected moldd to exit non-zero on bogus MOLDD_ANONAUTH, got nil")
+	case ctx.Err() != nil:
+		t.Fatalf("moldd did not exit within %s on bogus MOLDD_ANONAUTH (likely hung)", "5s")
+	}
+}

--- a/server/internal/smoke/fixtures.go
+++ b/server/internal/smoke/fixtures.go
@@ -1,0 +1,296 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package smoke
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// healthzWaitTimeout bounds how long StartServer waits for the
+// freshly spawned binary to start answering /healthz. The default is
+// generous enough to absorb cold-start I/O on slow CI runners and
+// short enough that a wedged process surfaces quickly during local
+// runs.
+const healthzWaitTimeout = 10 * time.Second
+
+// shutdownWaitTimeout bounds how long Server.Stop waits for the
+// process to exit after SIGTERM before escalating to SIGKILL and
+// failing the test. Matches the binary's own shutdownTimeout +
+// runnersShutdownTimeout sum plus a safety margin.
+const shutdownWaitTimeout = 20 * time.Second
+
+// ServerOptions is the configuration knob set passed to
+// Fixtures.StartServer. Each field is intentionally explicit rather
+// than env-string-based so a typo in a smoke case is a compile error.
+type ServerOptions struct {
+	// DataDir is where the binary writes its SQLCipher files. If
+	// empty, StartServer uses t.TempDir() so the data is wiped on
+	// test completion.
+	DataDir string
+
+	// MasterSeedBase64 is the value of MOLDD_MASTER_SEED. If empty,
+	// StartServer generates a fresh 32-byte random seed.
+	MasterSeedBase64 string
+
+	// EnableAnonauth toggles MOLDD_ANONAUTH=enforce vs disabled.
+	EnableAnonauth bool
+
+	// AnonauthDataDir overrides MOLDD_ANONAUTH_DATA_DIR. Ignored
+	// when EnableAnonauth is false. Defaults to a sub-directory of
+	// DataDir so anonauth and queue storage stay isolated.
+	AnonauthDataDir string
+
+	// ExtraEnv is appended verbatim to the child process's environ.
+	// Use it to set knobs (e.g. MOLDD_ANONAUTH_POW_BITS) that don't
+	// have first-class fields here.
+	ExtraEnv []string
+}
+
+// Server is a handle to a running moldd process. Tests use BaseURL to
+// build HTTP requests and Stop to drive a graceful shutdown. Kill is
+// the SIGKILL escape hatch for tests that intentionally simulate a
+// crash.
+//
+// Stop and Kill are safe to call from any goroutine and any number
+// of times: stopOnce serialises the first invocation, all subsequent
+// calls are no-ops.
+type Server struct {
+	BaseURL  string
+	DataDir  string
+	cmd      *exec.Cmd
+	stderr   *os.File
+	t        *testing.T
+	stopOnce sync.Once
+}
+
+// StartServer launches a moldd subprocess with the supplied options,
+// waits for /healthz to respond 200, and registers a t.Cleanup that
+// stops the process. Multiple cases may call StartServer; each gets
+// an isolated process on its own port and data directory.
+func (f *Fixtures) StartServer(t *testing.T, opts ServerOptions) *Server {
+	t.Helper()
+
+	dataDir := opts.DataDir
+	if dataDir == "" {
+		dataDir = t.TempDir()
+	}
+	seed := opts.MasterSeedBase64
+	if seed == "" {
+		raw := make([]byte, 32)
+		if _, err := rand.Read(raw); err != nil {
+			t.Fatalf("smoke: rand seed: %v", err)
+		}
+		seed = base64.StdEncoding.EncodeToString(raw)
+	}
+	addr, err := reservePort()
+	if err != nil {
+		t.Fatalf("smoke: reserve port: %v", err)
+	}
+	stderr, err := os.CreateTemp("", "moldd-smoke-*.stderr.log")
+	if err != nil {
+		t.Fatalf("smoke: stderr tempfile: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = stderr.Close()
+		_ = os.Remove(stderr.Name())
+	})
+
+	env := []string{
+		"MOLDD_ADDR=" + addr,
+		"MOLDD_STORAGE=sqlite",
+		"MOLDD_MASTER_SEED=" + seed,
+		"MOLDD_DATA_DIR=" + dataDir,
+		"MOLDD_LOG_LEVEL=warn",
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + os.Getenv("HOME"),
+	}
+	if opts.EnableAnonauth {
+		anonDir := opts.AnonauthDataDir
+		if anonDir == "" {
+			anonDir = dataDir + "/anonauth"
+		}
+		// Use the production defaults for every anonauth knob so
+		// smoke validates the actual deployed configuration. The
+		// default difficulty (20 bits) is cheap in absolute terms
+		// — SHA-256 grinding hits ~10 ms on a modern CPU — so
+		// running with it adds negligible suite time while making
+		// sure a future regression in the default cannot land
+		// without breaking the smoke job.
+		env = append(env,
+			"MOLDD_ANONAUTH=enforce",
+			"MOLDD_ANONAUTH_DATA_DIR="+anonDir,
+		)
+	}
+	env = append(env, opts.ExtraEnv...)
+
+	cmd := exec.Command(f.BinaryPath)
+	cmd.Env = env
+	cmd.Stdout = io.Discard
+	cmd.Stderr = stderr
+	// Stop targets the child by PID via cmd.Process.Signal, so
+	// process-group manipulation buys nothing; leaving the child in
+	// the test runner's group means a Ctrl-C against `go test`
+	// propagates to moldd children naturally instead of leaving
+	// them as zombies.
+
+	if startErr := cmd.Start(); startErr != nil {
+		t.Fatalf("smoke: start moldd: %v", startErr)
+	}
+
+	srv := &Server{
+		BaseURL: "http://" + addr,
+		DataDir: dataDir,
+		cmd:     cmd,
+		stderr:  stderr,
+		t:       t,
+	}
+	t.Cleanup(srv.Stop)
+
+	if err := waitForHealthz(srv.BaseURL, healthzWaitTimeout); err != nil {
+		dumpStderr(t, stderr)
+		t.Fatalf("smoke: %v", err)
+	}
+	return srv
+}
+
+// Stop sends SIGTERM and waits for graceful exit, failing the test if
+// the process does not exit within shutdownWaitTimeout. Safe to call
+// any number of times from any goroutine: the work runs at most once
+// thanks to stopOnce.
+func (s *Server) Stop() {
+	s.stopOnce.Do(func() {
+		if s.cmd.Process == nil {
+			return
+		}
+		_ = s.cmd.Process.Signal(syscall.SIGTERM)
+		select {
+		case waitErr := <-waitForExit(s.cmd):
+			if waitErr != nil {
+				// Non-zero exit on graceful shutdown is a real
+				// failure — surface it and dump stderr so the
+				// cause lands in the test log.
+				dumpStderr(s.t, s.stderr)
+				s.t.Fatalf("smoke: moldd exited with error after SIGTERM: %v", waitErr)
+			}
+		case <-time.After(shutdownWaitTimeout):
+			_ = s.cmd.Process.Kill()
+			<-waitForExit(s.cmd)
+			dumpStderr(s.t, s.stderr)
+			s.t.Fatalf("smoke: moldd did not exit within %s of SIGTERM", shutdownWaitTimeout)
+		}
+	})
+}
+
+// Kill sends SIGKILL and waits for the process to be reaped. Used by
+// restart-style cases that need to simulate a crash. Safe to call
+// any number of times from any goroutine.
+func (s *Server) Kill() {
+	s.stopOnce.Do(func() {
+		if s.cmd.Process == nil {
+			return
+		}
+		_ = s.cmd.Process.Kill()
+		<-waitForExit(s.cmd)
+	})
+}
+
+// waitForExit fires off cmd.Wait in a goroutine and returns a
+// channel that delivers the wait error (or nil) exactly once. Used
+// by both Stop and Kill so the wait-then-select pattern is
+// expressed identically in both code paths.
+func waitForExit(cmd *exec.Cmd) <-chan error {
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	return done
+}
+
+// reservePort grabs a free TCP port from the kernel and immediately
+// closes the listener. The window between close and the moldd child
+// re-binding is small enough that races are rare in practice; the
+// alternative (passing an inherited file descriptor) requires
+// per-platform plumbing that isn't worth the complexity for a smoke
+// suite.
+func reservePort() (string, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", err
+	}
+	addr := l.Addr().String()
+	if closeErr := l.Close(); closeErr != nil {
+		return "", closeErr
+	}
+	return addr, nil
+}
+
+// waitForHealthz polls /healthz with exponential-ish backoff until
+// it returns 200 or the timeout elapses. The HTTP client is reused
+// across iterations so its connection pool can warm up — important
+// when /healthz races a slow startup and we hit it many times.
+func waitForHealthz(baseURL string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	delay := 50 * time.Millisecond
+	client := &http.Client{Timeout: 1 * time.Second}
+	var lastErr error
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/healthz", nil)
+		if err != nil {
+			cancel()
+			return fmt.Errorf("build healthz request: %w", err)
+		}
+		resp, err := client.Do(req)
+		cancel()
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+			lastErr = fmt.Errorf("healthz returned %d", resp.StatusCode)
+		} else if !errors.Is(err, context.DeadlineExceeded) {
+			lastErr = err
+		}
+		time.Sleep(delay)
+		if delay < 500*time.Millisecond {
+			delay *= 2
+		}
+	}
+	if lastErr != nil {
+		return fmt.Errorf("healthz did not become ready within %s: %w", timeout, lastErr)
+	}
+	return fmt.Errorf("healthz did not become ready within %s", timeout)
+}
+
+// dumpStderr copies the captured stderr file to the test log so
+// failures include the binary's own complaint rather than a bare
+// "exit 1".
+func dumpStderr(t *testing.T, f *os.File) {
+	t.Helper()
+	if _, err := f.Seek(0, 0); err != nil {
+		t.Logf("smoke: stderr seek: %v", err)
+		return
+	}
+	data, err := io.ReadAll(f)
+	if err != nil {
+		t.Logf("smoke: stderr read: %v", err)
+		return
+	}
+	if len(data) == 0 {
+		return
+	}
+	t.Logf("smoke: moldd stderr:\n%s", data)
+}

--- a/server/internal/smoke/queue_smoke.go
+++ b/server/internal/smoke/queue_smoke.go
@@ -1,0 +1,222 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//go:build smoke
+
+package smoke
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/WissCore/moldchat/server/internal/auth"
+	"github.com/WissCore/moldchat/server/internal/queue"
+)
+
+func init() {
+	RegisterCase(Case{
+		Name: "QueueLifecycleHappyPath",
+		Run:  queueLifecycleCase,
+	})
+}
+
+// queueLifecycleCase walks a queue end to end on a real moldd
+// process: create → put a blob → owner-authenticated list → owner-
+// authenticated delete. Mirrors the in-process httptest e2e but goes
+// through a real socket against the actually-built binary.
+func queueLifecycleCase(t *testing.T, fix *Fixtures) {
+	srv := fix.StartServer(t, ServerOptions{})
+
+	owner := mintOwner(t)
+	queueID := smokeCreateQueue(t, srv.BaseURL, owner)
+
+	const blob = "hello-from-smoke"
+	mid := smokePutMessage(t, srv.BaseURL, queueID, []byte(blob), "")
+	if mid == "" {
+		t.Fatal("put returned empty message_id")
+	}
+
+	got := smokeListSingleMessage(t, srv.BaseURL, queueID, owner)
+	if got != blob {
+		t.Fatalf("listed blob = %q, want %q", got, blob)
+	}
+
+	smokeDeleteMessage(t, srv.BaseURL, queueID, mid, owner)
+
+	// Listing after delete must yield zero messages.
+	if remaining := smokeListSingleMessage(t, srv.BaseURL, queueID, owner); remaining != "" {
+		t.Fatalf("queue still holds blob after delete: %q", remaining)
+	}
+}
+
+// smokeOwner is the credential pair used by the owner-authenticated
+// smoke flows. Only Ed25519 is exercised in the signing path; X25519
+// is registered alongside per the API contract but unused on the
+// wire today.
+type smokeOwner struct {
+	x25519Pub  []byte
+	ed25519Pub ed25519.PublicKey
+	ed25519Pri ed25519.PrivateKey
+}
+
+func mintOwner(t *testing.T) smokeOwner {
+	t.Helper()
+	x := make([]byte, queue.X25519PubKeyBytes)
+	if _, err := rand.Read(x); err != nil {
+		t.Fatalf("rand x25519: %v", err)
+	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519: %v", err)
+	}
+	return smokeOwner{x25519Pub: x, ed25519Pub: pub, ed25519Pri: priv}
+}
+
+func smokeCreateQueue(t *testing.T, baseURL string, owner smokeOwner) string {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{
+		"owner_x25519_pubkey":  base64.StdEncoding.EncodeToString(owner.x25519Pub),
+		"owner_ed25519_pubkey": base64.StdEncoding.EncodeToString(owner.ed25519Pub),
+	})
+	resp, err := http.Post(baseURL+"/v1/queues", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		buf, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create queue status %d: %s", resp.StatusCode, buf)
+	}
+	var got struct {
+		QueueID string `json:"queue_id"`
+	}
+	if decErr := json.NewDecoder(resp.Body).Decode(&got); decErr != nil {
+		t.Fatalf("decode queue: %v", decErr)
+	}
+	if got.QueueID == "" {
+		t.Fatalf("create queue returned empty id")
+	}
+	return got.QueueID
+}
+
+func smokePutMessage(t *testing.T, baseURL, queueID string, blob []byte, anonToken string) string {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPut, baseURL+"/v1/queues/"+queueID+"/messages", bytes.NewReader(blob))
+	if err != nil {
+		t.Fatalf("build put: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	if anonToken != "" {
+		req.Header.Set("X-Anonauth-Token", anonToken)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		buf, _ := io.ReadAll(resp.Body)
+		t.Fatalf("put status %d: %s", resp.StatusCode, buf)
+	}
+	var got struct {
+		MessageID string `json:"message_id"`
+	}
+	if decErr := json.NewDecoder(resp.Body).Decode(&got); decErr != nil {
+		t.Fatalf("decode put: %v", decErr)
+	}
+	return got.MessageID
+}
+
+func smokeListSingleMessage(t *testing.T, baseURL, queueID string, owner smokeOwner) string {
+	t.Helper()
+	req := smokeOwnerRequest(t, baseURL, queueID, http.MethodGet, "/v1/queues/"+queueID+"/messages", "", owner)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		buf, _ := io.ReadAll(resp.Body)
+		t.Fatalf("list status %d: %s", resp.StatusCode, buf)
+	}
+	var got struct {
+		Messages []struct {
+			Blob string `json:"blob"`
+		} `json:"messages"`
+	}
+	if decErr := json.NewDecoder(resp.Body).Decode(&got); decErr != nil {
+		t.Fatalf("decode list: %v", decErr)
+	}
+	if len(got.Messages) == 0 {
+		return ""
+	}
+	if len(got.Messages) > 1 {
+		t.Fatalf("list returned %d messages, smoke expects exactly one", len(got.Messages))
+	}
+	raw, err := base64.StdEncoding.DecodeString(got.Messages[0].Blob)
+	if err != nil {
+		t.Fatalf("decode blob: %v", err)
+	}
+	return string(raw)
+}
+
+func smokeDeleteMessage(t *testing.T, baseURL, queueID, mid string, owner smokeOwner) {
+	t.Helper()
+	req := smokeOwnerRequest(t, baseURL, queueID, http.MethodDelete, "/v1/queues/"+queueID+"/messages/"+mid, mid, owner)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNoContent {
+		buf, _ := io.ReadAll(resp.Body)
+		t.Fatalf("delete status %d: %s", resp.StatusCode, buf)
+	}
+}
+
+// smokeOwnerRequest builds a request with a fresh challenge nonce
+// signed by owner. resourceID binds the signature to the targeted
+// message id for DELETE; pass empty string for list/auth-challenge.
+func smokeOwnerRequest(t *testing.T, baseURL, queueID, method, target, resourceID string, owner smokeOwner) *http.Request {
+	t.Helper()
+	nonce := smokeFetchNonce(t, baseURL, queueID)
+	payload := auth.CanonicalPayload(nonce, queueID, method, resourceID)
+	sig := ed25519.Sign(owner.ed25519Pri, payload)
+	req, err := http.NewRequest(method, baseURL+target, nil)
+	if err != nil {
+		t.Fatalf("build %s %s: %v", method, target, err)
+	}
+	req.Header.Set("Authorization", auth.FormatAuthorization(sig, owner.ed25519Pub, nonce))
+	return req
+}
+
+func smokeFetchNonce(t *testing.T, baseURL, queueID string) []byte {
+	t.Helper()
+	resp, err := http.Get(fmt.Sprintf("%s/v1/queues/%s/auth-challenge", baseURL, queueID))
+	if err != nil {
+		t.Fatalf("auth-challenge: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("auth-challenge status %d", resp.StatusCode)
+	}
+	var got struct {
+		Nonce string `json:"nonce"`
+	}
+	if decErr := json.NewDecoder(resp.Body).Decode(&got); decErr != nil {
+		t.Fatalf("decode nonce: %v", decErr)
+	}
+	nonce, err := base64.StdEncoding.DecodeString(got.Nonce)
+	if err != nil {
+		t.Fatalf("decode nonce bytes: %v", err)
+	}
+	return nonce
+}

--- a/server/internal/smoke/restart_smoke.go
+++ b/server/internal/smoke/restart_smoke.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//go:build smoke
+
+package smoke
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"testing"
+)
+
+func init() {
+	RegisterCase(Case{
+		Name: "DataSurvivesProcessRestart",
+		Run:  restartDurabilityCase,
+	})
+}
+
+// restartDurabilityCase confirms a queue and its messages survive a
+// SIGKILL'd process when the same data dir and master seed are reused
+// on the next start. This is the smoke-level cousin of the
+// SQLCipher integration test; it adds value by going through the
+// real binary, the real OS-level file write path, and a real crash
+// rather than a Close()-then-New() round trip in the same process.
+func restartDurabilityCase(t *testing.T, fix *Fixtures) {
+	dataDir := t.TempDir()
+	seed := freshSeed(t)
+
+	first := fix.StartServer(t, ServerOptions{DataDir: dataDir, MasterSeedBase64: seed})
+	owner := mintOwner(t)
+	queueID := smokeCreateQueue(t, first.BaseURL, owner)
+	const blob = "survives-the-crash"
+	if mid := smokePutMessage(t, first.BaseURL, queueID, []byte(blob), ""); mid == "" {
+		t.Fatal("first put returned empty id")
+	}
+	first.Kill() // simulate a hard crash, no graceful shutdown
+
+	second := fix.StartServer(t, ServerOptions{DataDir: dataDir, MasterSeedBase64: seed})
+	if got := smokeListSingleMessage(t, second.BaseURL, queueID, owner); got != blob {
+		t.Fatalf("after restart: blob = %q, want %q", got, blob)
+	}
+}
+
+func freshSeed(t *testing.T) string {
+	t.Helper()
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		t.Fatalf("rand seed: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(raw)
+}

--- a/server/internal/smoke/smoke.go
+++ b/server/internal/smoke/smoke.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package smoke holds the binary-level smoke test suite.
+//
+// A smoke test exercises the actually-built moldd binary against
+// realistic configuration: it spawns the process, waits for /healthz,
+// drives the public HTTP API the way an external client would, and
+// checks the process exits cleanly on SIGTERM. Smoke tests catch the
+// class of regressions that slip past unit and integration tests:
+// env-variable wiring in main.go, signal handling, runner
+// orchestration, build-time dependencies (CGo, SQLCipher), and the
+// happy-path wire format on a real socket.
+//
+// # Registration model
+//
+// Each smoke scenario is a Case registered at package init time:
+//
+//	package smoke
+//
+//	func init() {
+//	    RegisterCase(Case{
+//	        Name: "QueueLifecycle",
+//	        Run:  func(t *testing.T, fix *Fixtures) { ... },
+//	    })
+//	}
+//
+// The runner in suite_test.go reads the global registry and invokes
+// each case as a subtest. Adding a new smoke scenario is a one-file
+// change with no edits to lefthook, mise, or the CI workflow — the
+// registry is the single source of truth.
+//
+// # How to run
+//
+// Direct:
+//
+//	cd server && go test -tags smoke -count=1 -timeout=2m ./internal/smoke/
+//
+// Via mise (mirrors what CI runs):
+//
+//	mise run smoke
+package smoke
+
+import "testing"
+
+// Fixtures bundles the shared setup that every Case needs: the path
+// to a freshly built moldd binary, plus helpers for starting and
+// stopping isolated server instances. The runner constructs one
+// Fixtures per suite invocation so the binary is built only once.
+type Fixtures struct {
+	// BinaryPath is the absolute filesystem path to the built moldd
+	// binary the suite will exec.
+	BinaryPath string
+}
+
+// Case is one smoke scenario. The Run function receives a *testing.T
+// scoped to a subtest plus the shared Fixtures. Each Case is
+// responsible for any servers it starts; using fix.StartServer
+// registers the right cleanup automatically.
+type Case struct {
+	Name string
+	Run  func(t *testing.T, fix *Fixtures)
+}
+
+// registry is the package-global slice of registered cases. Cases
+// self-register via init(); the runner reads Registered() to iterate.
+var registry []Case
+
+// RegisterCase appends a Case to the registry. Intended to be called
+// from package-init in a per-scenario file. Names must be unique
+// across the suite — RegisterCase panics on collision so a copy-paste
+// bug surfaces at build time rather than as a silent shadow.
+func RegisterCase(c Case) {
+	if c.Name == "" {
+		panic("smoke: RegisterCase requires a non-empty Name")
+	}
+	if c.Run == nil {
+		panic("smoke: RegisterCase requires a non-nil Run")
+	}
+	for _, existing := range registry {
+		if existing.Name == c.Name {
+			panic("smoke: duplicate Case name " + c.Name)
+		}
+	}
+	registry = append(registry, c)
+}
+
+// Registered returns a defensive copy of the current registry. The
+// runner walks this slice in registration order so failures are
+// reported under stable subtest names regardless of map iteration.
+func Registered() []Case {
+	out := make([]Case, len(registry))
+	copy(out, registry)
+	return out
+}

--- a/server/internal/smoke/suite_test.go
+++ b/server/internal/smoke/suite_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Alan Wiss <alan@moldchat.com>
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//go:build smoke
+
+package smoke_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/WissCore/moldchat/server/internal/smoke"
+)
+
+// suiteFixtures is the shared Fixtures handed to every Case. Built
+// once per `go test` invocation by TestMain so the moldd binary is
+// compiled exactly once regardless of how many cases are registered.
+var suiteFixtures *smoke.Fixtures
+
+// TestMain builds the moldd binary into a tempdir, points the
+// Fixtures at it, runs the suite, and cleans up. A non-zero exit
+// from the build aborts the suite immediately with the build's
+// stderr in the test log so a CGo / SQLCipher regression surfaces
+// without first running every case.
+func TestMain(m *testing.M) {
+	os.Exit(runSuite(m))
+}
+
+// runSuite is split out of TestMain so the cleanup defer runs even
+// when m.Run reports a non-zero exit code; calling os.Exit inside
+// TestMain bypasses any defers there but not here.
+func runSuite(m *testing.M) int {
+	tmpDir, err := os.MkdirTemp("", "moldd-smoke-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "smoke: tempdir: %v\n", err)
+		return 1
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	binPath := filepath.Join(tmpDir, "moldd")
+	build := exec.Command("go", "build", "-o", binPath, "./cmd/moldd")
+	// The smoke package lives at server/internal/smoke; the module
+	// root is two levels up. Set Dir explicitly so `go build` finds
+	// the right go.mod regardless of where `go test` was invoked.
+	build.Dir = filepath.Join("..", "..")
+	build.Stdout = os.Stderr
+	build.Stderr = os.Stderr
+	if buildErr := build.Run(); buildErr != nil {
+		fmt.Fprintf(os.Stderr, "smoke: go build moldd: %v\n", buildErr)
+		return 1
+	}
+
+	suiteFixtures = &smoke.Fixtures{BinaryPath: binPath}
+	return m.Run()
+}
+
+// TestSuite is the single entry point that drives every registered
+// Case as a subtest. Cases run in parallel because each spawns its
+// own moldd process on its own port and data directory; the
+// per-case fixtures are isolated.
+func TestSuite(t *testing.T) {
+	t.Parallel()
+	cases := smoke.Registered()
+	if len(cases) == 0 {
+		t.Fatal("smoke: no cases registered — has any *_smoke.go file dropped its build tag?")
+	}
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			c.Run(t, suiteFixtures)
+		})
+	}
+}


### PR DESCRIPTION
Three independent commits stacked on this branch:

1. `feat(server)`: L4 anonauth — POPRF gate on PUT /messages with bootstrap-PoW pseudonyms, hashcash registration, per-epoch rate limit, replay protection. Cleanup runner sweeps expired pseudonyms.
2. `test(server)`: smoke suite under `server/internal/smoke/` with case registry pattern. Six cases covering binary lifecycle, queue happy path, anonauth e2e, restart durability. `mise run smoke` mirrors CI.
3. `ci`: workflow orchestrator. Single `ci.yml` calls 9 reusable workflows via `workflow_call`, gated on a path-filter for backup-roundtrip and docker. `ci-success` summary job is the single required check for branch protection.

## Branch protection migration

The pre-existing ruleset `main-branch-protection` requires 8 individual job names (`server (Go)`, `gitleaks`, `zizmor`, `analyze (go)`, `scan`, `dco`, `dep-review`, `validate`). With the orchestrator landed those names are emitted under different paths. The ruleset must be updated to require only `ci-success`, `dep-review`, and `validate` once this PR's CI run reveals the actual context names. See `docs/runbook/branch-protection.md`.