### PR TITLE
fix(ci): pin SLSA generator by tag to satisfy builder-fetch ref check

### DIFF
--- a/.github/workflows/sigstore-sign.yml
+++ b/.github/workflows/sigstore-sign.yml
@@ -105,8 +105,12 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    # SLSA trusted-builder is identified by tag ref; pinning by SHA breaks slsa-verifier's BuilderID check.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a  # v2.1.0  # zizmor: ignore[unpinned-uses]
+    # SLSA trusted-builder is identified by tag ref; pinning by SHA
+    # breaks both slsa-verifier's BuilderID check AND the upstream
+    # builder-fetch.sh download (slsa-framework/slsa-github-generator#4216,
+    # error: "slsa-generator-generic-linux-amd64: No such file or
+    # directory"). The version tag is the load-bearing pin here.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0  # zizmor: ignore[unpinned-uses]
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true


### PR DESCRIPTION
Renovate switched the slsa-github-generator reusable workflow from `@v2.1.0` to a SHA pin in #36 ("chore(deps): pin dependencies"), unaware that upstream `builder-fetch.sh` validates the calling ref against `^refs/tags/vX\.Y\.Z$` and accepts tag refs only. With a SHA pin the validation fails silently, the SLSA builder binary is never downloaded, and the `provenance/generator` job fails with `slsa-generator-generic-linux-amd64: No such file or directory` (this just happened on the `server-v0.1.7` release run).

Reverted to `@v2.1.0`. The existing `# zizmor: ignore[unpinned-uses]` exception remains valid because tag pinning is a structural requirement of SLSA's trusted-builder identity model, not a slip in our supply-chain hygiene.

Upstream issue: slsa-framework/slsa-github-generator#4216.