### PR TITLE
chore(renovate): keep SLSA generator pinned by tag, not SHA

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,12 @@
       "addLabels": ["crypto-review-required"]
     },
     {
+      "description": "SLSA generator: must stay tag-pinned. Upstream builder-fetch.sh validates the calling ref against ^refs/tags/vX.Y.Z$ and refuses SHA references; the BuilderID baked into the generated provenance is the tag, so SHA-pinning also breaks slsa-verifier downstream. See slsa-framework/slsa-github-generator#4216.",
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["slsa-framework/slsa-github-generator"],
+      "pinDigests": false
+    },
+    {
       "description": "Dev tooling: auto-merge minor/patch after CI",
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
Tells Renovate not to digest-pin slsa-framework/slsa-github-generator, because the upstream builder-fetch.sh accepts only refs/tags/vX.Y.Z and the generated provenance's BuilderID is the tag — both reasons SHA pinning broke the v0.1.7 release.